### PR TITLE
Return all Cookies in a response - NOT JUST ONE

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
@@ -446,18 +446,23 @@ public final class NetworkingModule extends ReactContextBaseJavaModule {
 
   private static WritableMap translateHeaders(Headers headers) {
     WritableMap responseHeaders = Arguments.createMap();
-    for (int i = 0; i < headers.size(); i++) {
+    HashMap<String, String> responseHeadersMap = new HashMap<>();
+
+   for (int i = 0; i < headers.size(); i++) {
       String headerName = headers.name(i);
-      // multiple values for the same header
-      if (responseHeaders.hasKey(headerName)) {
-        responseHeaders.putString(
-            headerName,
-            responseHeaders.getString(headerName) + ", " + headers.value(i));
+      String headerValue = headers.value(i);
+
+     if(responseHeadersMap.containsKey(headerName)) {
+        String existingValueForHeaderName = responseHeadersMap.get(headerName);
+        responseHeadersMap.put(headerName, existingValueForHeaderName + ", " + headerValue);
+        responseHeaders.putString(headerName, existingValueForHeaderName + ", " + headerValue);
       } else {
-        responseHeaders.putString(headerName, headers.value(i));
-      }
-    }
-    return responseHeaders;
+       responseHeadersMap.put(headerName, headerValue);
+       responseHeaders.putString(headerName, headerValue);
+     }
+   }
+
+   return responseHeaders;
   }
 
   @ReactMethod


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

Jack Byrne

react-native only returns ONE cookie in HTTP responses. Unfortunately, the Cookie I need is not the lucky one. This PR is to return all Cookies in the Response header. If the Cookie already exists in the responseHeadersMap, it is replaced by the value returned in the HTTP Response

## Test Plan

Dont have any because I could not get react-native to build locally after spending days on it
VERY FRUSTRATING

## Related PRs


## Release Notes
React Native is great to work with but this breaking change is making it impossible for us to use this framework. Pity!

