### PR TITLE
Reapply expo fixes with respect to bare workflow

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -128,7 +128,7 @@ public class ReactDelegate {
           Assertions.assertNotNull(mDoubleTapReloadRecognizer)
               .didDoubleTapR(keyCode, mActivity.getCurrentFocus());
       if (didDoubleTapR) {
-        getReactNativeHost().getReactInstanceManager().getDevSupportManager().handleReloadJS();
+        getReactNativeHost().getReactInstanceManager().getDevSupportManager().reloadExpoApp();
         return true;
       }
     }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.java
@@ -21,159 +21,169 @@ import com.facebook.react.packagerconnection.PackagerConnectionSettings;
  * this class implements an external interface {@link DeveloperSettings}.
  */
 @VisibleForTesting
-public class DevInternalSettings
-    implements DeveloperSettings, SharedPreferences.OnSharedPreferenceChangeListener {
+public class DevInternalSettings implements DeveloperSettings, SharedPreferences.OnSharedPreferenceChangeListener {
 
-  private static final String PREFS_FPS_DEBUG_KEY = "fps_debug";
-  private static final String PREFS_JS_DEV_MODE_DEBUG_KEY = "js_dev_mode_debug";
-  private static final String PREFS_JS_MINIFY_DEBUG_KEY = "js_minify_debug";
-  private static final String PREFS_JS_BUNDLE_DELTAS_KEY = "js_bundle_deltas";
-  private static final String PREFS_JS_BUNDLE_DELTAS_CPP_KEY = "js_bundle_deltas_cpp";
-  private static final String PREFS_ANIMATIONS_DEBUG_KEY = "animations_debug";
-  // This option is no longer exposed in the dev menu UI.
-  // It was renamed in D15958697 so it doesn't get stuck with no way to turn it off:
-  private static final String PREFS_RELOAD_ON_JS_CHANGE_KEY = "reload_on_js_change_LEGACY";
-  private static final String PREFS_INSPECTOR_DEBUG_KEY = "inspector_debug";
-  private static final String PREFS_HOT_MODULE_REPLACEMENT_KEY = "hot_module_replacement";
-  private static final String PREFS_REMOTE_JS_DEBUG_KEY = "remote_js_debug";
-  private static final String PREFS_START_SAMPLING_PROFILER_ON_INIT =
-      "start_sampling_profiler_on_init";
+    public static String PREFS_FPS_DEBUG_KEY = "fps_debug";
 
-  private final SharedPreferences mPreferences;
-  private final Listener mListener;
-  private final PackagerConnectionSettings mPackagerConnectionSettings;
-  private final boolean mSupportsNativeDeltaClients;
+    public static String PREFS_JS_DEV_MODE_DEBUG_KEY = "js_dev_mode_debug";
 
-  public static DevInternalSettings withoutNativeDeltaClient(
-      Context applicationContext, Listener listener) {
-    return new DevInternalSettings(applicationContext, listener, false);
-  }
+    public static String PREFS_JS_MINIFY_DEBUG_KEY = "js_minify_debug";
 
-  public DevInternalSettings(Context applicationContext, Listener listener) {
-    this(applicationContext, listener, true);
-  }
+    public static String PREFS_JS_BUNDLE_DELTAS_KEY = "js_bundle_deltas";
 
-  private DevInternalSettings(
-      Context applicationContext, Listener listener, boolean supportsNativeDeltaClients) {
-    mListener = listener;
-    mPreferences = PreferenceManager.getDefaultSharedPreferences(applicationContext);
-    mPreferences.registerOnSharedPreferenceChangeListener(this);
-    mPackagerConnectionSettings = new PackagerConnectionSettings(applicationContext);
-    mSupportsNativeDeltaClients = supportsNativeDeltaClients;
-  }
+    public static String PREFS_JS_BUNDLE_DELTAS_CPP_KEY = "js_bundle_deltas_cpp";
 
-  public PackagerConnectionSettings getPackagerConnectionSettings() {
-    return mPackagerConnectionSettings;
-  }
+    public static String PREFS_ANIMATIONS_DEBUG_KEY = "animations_debug";
 
-  @Override
-  public boolean isFpsDebugEnabled() {
-    return mPreferences.getBoolean(PREFS_FPS_DEBUG_KEY, false);
-  }
+    // This option is no longer exposed in the dev menu UI.
+    // It was renamed in D15958697 so it doesn't get stuck with no way to turn it off:
+    public static String PREFS_RELOAD_ON_JS_CHANGE_KEY = "reload_on_js_change_LEGACY";
 
-  public void setFpsDebugEnabled(boolean enabled) {
-    mPreferences.edit().putBoolean(PREFS_FPS_DEBUG_KEY, enabled).apply();
-  }
+    public static String PREFS_INSPECTOR_DEBUG_KEY = "inspector_debug";
 
-  @Override
-  public boolean isAnimationFpsDebugEnabled() {
-    return mPreferences.getBoolean(PREFS_ANIMATIONS_DEBUG_KEY, false);
-  }
+    public static String PREFS_HOT_MODULE_REPLACEMENT_KEY = "hot_module_replacement";
 
-  @Override
-  public boolean isJSDevModeEnabled() {
-    return mPreferences.getBoolean(PREFS_JS_DEV_MODE_DEBUG_KEY, true);
-  }
+    public static String PREFS_REMOTE_JS_DEBUG_KEY = "remote_js_debug";
 
-  public void setJSDevModeEnabled(boolean value) {
-    mPreferences.edit().putBoolean(PREFS_JS_DEV_MODE_DEBUG_KEY, value).apply();
-  }
+    public static String PREFS_START_SAMPLING_PROFILER_ON_INIT = "start_sampling_profiler_on_init";
 
-  @Override
-  public boolean isJSMinifyEnabled() {
-    return mPreferences.getBoolean(PREFS_JS_MINIFY_DEBUG_KEY, false);
-  }
+    public final SharedPreferences mPreferences;
 
-  public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-    if (mListener != null) {
-      if (PREFS_FPS_DEBUG_KEY.equals(key)
-          || PREFS_RELOAD_ON_JS_CHANGE_KEY.equals(key)
-          || PREFS_JS_DEV_MODE_DEBUG_KEY.equals(key)
-          || PREFS_JS_BUNDLE_DELTAS_KEY.equals(key)
-          || PREFS_JS_BUNDLE_DELTAS_CPP_KEY.equals(key)
-          || PREFS_START_SAMPLING_PROFILER_ON_INIT.equals(key)
-          || PREFS_JS_MINIFY_DEBUG_KEY.equals(key)) {
-        mListener.onInternalSettingsChanged();
-      }
+    public final Listener mListener;
+
+    public final PackagerConnectionSettings mPackagerConnectionSettings;
+
+    public final boolean mSupportsNativeDeltaClients;
+
+    public static DevInternalSettings withoutNativeDeltaClient(Context applicationContext, Listener listener) {
+        return new DevInternalSettings(applicationContext, listener, false);
     }
-  }
 
-  public boolean isHotModuleReplacementEnabled() {
-    return mPreferences.getBoolean(PREFS_HOT_MODULE_REPLACEMENT_KEY, true);
-  }
+    public DevInternalSettings(Context applicationContext, Listener listener) {
+        this(applicationContext, listener, true);
+    }
 
-  public void setHotModuleReplacementEnabled(boolean enabled) {
-    mPreferences.edit().putBoolean(PREFS_HOT_MODULE_REPLACEMENT_KEY, enabled).apply();
-  }
+    private DevInternalSettings(Context applicationContext, Listener listener, boolean supportsNativeDeltaClients) {
+        mListener = listener;
+        mPreferences = PreferenceManager.getDefaultSharedPreferences(applicationContext);
+        mPreferences.registerOnSharedPreferenceChangeListener(this);
+        mPackagerConnectionSettings = new PackagerConnectionSettings(applicationContext);
+        mSupportsNativeDeltaClients = supportsNativeDeltaClients;
+    }
 
-  public boolean isReloadOnJSChangeEnabled() {
-    return mPreferences.getBoolean(PREFS_RELOAD_ON_JS_CHANGE_KEY, false);
-  }
+    public PackagerConnectionSettings getPackagerConnectionSettings() {
+        return mPackagerConnectionSettings;
+    }
 
-  public void setReloadOnJSChangeEnabled(boolean enabled) {
-    mPreferences.edit().putBoolean(PREFS_RELOAD_ON_JS_CHANGE_KEY, enabled).apply();
-  }
+    @Override
+    public boolean isFpsDebugEnabled() {
+        return mPreferences.getBoolean(PREFS_FPS_DEBUG_KEY, false);
+    }
 
-  public boolean isElementInspectorEnabled() {
-    return mPreferences.getBoolean(PREFS_INSPECTOR_DEBUG_KEY, false);
-  }
+    public void setFpsDebugEnabled(boolean enabled) {
+        mPreferences.edit().putBoolean(PREFS_FPS_DEBUG_KEY, enabled).apply();
+    }
 
-  public void setElementInspectorEnabled(boolean enabled) {
-    mPreferences.edit().putBoolean(PREFS_INSPECTOR_DEBUG_KEY, enabled).apply();
-  }
+    @Override
+    public boolean isAnimationFpsDebugEnabled() {
+        return mPreferences.getBoolean(PREFS_ANIMATIONS_DEBUG_KEY, false);
+    }
 
-  @SuppressLint("SharedPreferencesUse")
-  public boolean isBundleDeltasEnabled() {
-    return mPreferences.getBoolean(PREFS_JS_BUNDLE_DELTAS_KEY, false);
-  }
+    @Override
+    public boolean isJSDevModeEnabled() {
+        return mPreferences.getBoolean(PREFS_JS_DEV_MODE_DEBUG_KEY, true);
+    }
 
-  @SuppressLint("SharedPreferencesUse")
-  public void setBundleDeltasEnabled(boolean enabled) {
-    mPreferences.edit().putBoolean(PREFS_JS_BUNDLE_DELTAS_KEY, enabled).apply();
-  }
+    public void setJSDevModeEnabled(boolean value) {
+        mPreferences.edit().putBoolean(PREFS_JS_DEV_MODE_DEBUG_KEY, value).apply();
+    }
 
-  @SuppressLint("SharedPreferencesUse")
-  public boolean isBundleDeltasCppEnabled() {
-    return mSupportsNativeDeltaClients
-        && mPreferences.getBoolean(PREFS_JS_BUNDLE_DELTAS_CPP_KEY, false);
-  }
+    @Override
+    public boolean isJSMinifyEnabled() {
+        return mPreferences.getBoolean(PREFS_JS_MINIFY_DEBUG_KEY, false);
+    }
 
-  @SuppressLint("SharedPreferencesUse")
-  public void setBundleDeltasCppEnabled(boolean enabled) {
-    mPreferences.edit().putBoolean(PREFS_JS_BUNDLE_DELTAS_CPP_KEY, enabled).apply();
-  }
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        if (mListener != null) {
+            if (PREFS_FPS_DEBUG_KEY.equals(key) || PREFS_RELOAD_ON_JS_CHANGE_KEY.equals(key) || PREFS_JS_DEV_MODE_DEBUG_KEY.equals(key) || PREFS_JS_BUNDLE_DELTAS_KEY.equals(key) || PREFS_JS_BUNDLE_DELTAS_CPP_KEY.equals(key) || PREFS_START_SAMPLING_PROFILER_ON_INIT.equals(key) || PREFS_JS_MINIFY_DEBUG_KEY.equals(key)) {
+                mListener.onInternalSettingsChanged();
+            }
+        }
+    }
 
-  @Override
-  public boolean isNuclideJSDebugEnabled() {
-    return ReactBuildConfig.IS_INTERNAL_BUILD && ReactBuildConfig.DEBUG;
-  }
+    public boolean isHotModuleReplacementEnabled() {
+        return mPreferences.getBoolean(PREFS_HOT_MODULE_REPLACEMENT_KEY, true);
+    }
 
-  @Override
-  public boolean isRemoteJSDebugEnabled() {
-    return mPreferences.getBoolean(PREFS_REMOTE_JS_DEBUG_KEY, false);
-  }
+    public void setHotModuleReplacementEnabled(boolean enabled) {
+        mPreferences.edit().putBoolean(PREFS_HOT_MODULE_REPLACEMENT_KEY, enabled).apply();
+    }
 
-  @Override
-  public void setRemoteJSDebugEnabled(boolean remoteJSDebugEnabled) {
-    mPreferences.edit().putBoolean(PREFS_REMOTE_JS_DEBUG_KEY, remoteJSDebugEnabled).apply();
-  }
+    public boolean isReloadOnJSChangeEnabled() {
+      // NOTE(brentvatne): This is not possible to enable/disable so we should always disable it for
+      // now. I managed to get into a state where fast refresh wouldn't work because live reload
+      // would kick in every time and there was no way to turn it off from the dev menu.
+        return false;
+      // return mPreferences.getBoolean(PREFS_RELOAD_ON_JS_CHANGE_KEY, true);
+    }
 
-  @Override
-  public boolean isStartSamplingProfilerOnInit() {
-    return mPreferences.getBoolean(PREFS_START_SAMPLING_PROFILER_ON_INIT, false);
-  }
+    public void setReloadOnJSChangeEnabled(boolean enabled) {
+      // NOTE(brentvatne): We don't need to do anything here because this option is always false
+      // mPreferences.edit().putBoolean(PREFS_RELOAD_ON_JS_CHANGE_KEY, enabled).apply();
+    }
 
-  public interface Listener {
-    void onInternalSettingsChanged();
-  }
+    public boolean isElementInspectorEnabled() {
+        return mPreferences.getBoolean(PREFS_INSPECTOR_DEBUG_KEY, false);
+    }
+
+    public void setElementInspectorEnabled(boolean enabled) {
+        mPreferences.edit().putBoolean(PREFS_INSPECTOR_DEBUG_KEY, enabled).apply();
+    }
+
+    @SuppressLint("SharedPreferencesUse")
+    public boolean isBundleDeltasEnabled() {
+        return mPreferences.getBoolean(PREFS_JS_BUNDLE_DELTAS_KEY, false);
+    }
+
+    @SuppressLint("SharedPreferencesUse")
+    public void setBundleDeltasEnabled(boolean enabled) {
+        mPreferences.edit().putBoolean(PREFS_JS_BUNDLE_DELTAS_KEY, enabled).apply();
+    }
+
+    @SuppressLint("SharedPreferencesUse")
+    public boolean isBundleDeltasCppEnabled() {
+        return mSupportsNativeDeltaClients && mPreferences.getBoolean(PREFS_JS_BUNDLE_DELTAS_CPP_KEY, false);
+    }
+
+    @SuppressLint("SharedPreferencesUse")
+    public void setBundleDeltasCppEnabled(boolean enabled) {
+        mPreferences.edit().putBoolean(PREFS_JS_BUNDLE_DELTAS_CPP_KEY, enabled).apply();
+    }
+
+    @Override
+    public boolean isNuclideJSDebugEnabled() {
+        return ReactBuildConfig.IS_INTERNAL_BUILD && ReactBuildConfig.DEBUG;
+    }
+
+    @Override
+    public boolean isRemoteJSDebugEnabled() {
+        return mPreferences.getBoolean(PREFS_REMOTE_JS_DEBUG_KEY, false);
+    }
+
+    @Override
+    public void setRemoteJSDebugEnabled(boolean remoteJSDebugEnabled) {
+        mPreferences.edit().putBoolean(PREFS_REMOTE_JS_DEBUG_KEY, remoteJSDebugEnabled).apply();
+    }
+
+    @Override
+    public boolean isStartSamplingProfilerOnInit() {
+        return mPreferences.getBoolean(PREFS_START_SAMPLING_PROFILER_ON_INIT, false);
+    }
+
+    public interface Listener {
+
+        void onInternalSettingsChanged();
+    }
+
+public int exponentActivityId = -1;
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.java
@@ -117,16 +117,11 @@ public class DevInternalSettings
   }
 
   public boolean isReloadOnJSChangeEnabled() {
-    // NOTE(brentvatne): This is not possible to enable/disable so we should always disable it for
-    // now. I managed to get into a state where fast refresh wouldn't work because live reload
-    // would kick in every time and there was no way to turn it off from the dev menu.
-    return false;
-    // return mPreferences.getBoolean(PREFS_RELOAD_ON_JS_CHANGE_KEY, true);
+    return mPreferences.getBoolean(PREFS_RELOAD_ON_JS_CHANGE_KEY, false);
   }
 
   public void setReloadOnJSChangeEnabled(boolean enabled) {
-    // NOTE(brentvatne): We don't need to do anything here because this option is always false
-    // mPreferences.edit().putBoolean(PREFS_RELOAD_ON_JS_CHANGE_KEY, enabled).apply();
+    mPreferences.edit().putBoolean(PREFS_RELOAD_ON_JS_CHANGE_KEY, enabled).apply();
   }
 
   public boolean isElementInspectorEnabled() {
@@ -181,6 +176,4 @@ public class DevInternalSettings
   public interface Listener {
     void onInternalSettingsChanged();
   }
-
-  public int exponentActivityId = -1;
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -424,13 +424,22 @@ public class DevSupportManagerImpl
         });
   }
 
+  private int getExponentActivityId() {
+    return -1;
+  }
+
   @Override
   public void reloadExpoApp() {
     try {
-      int activityId = mDevServerHelper.mSettings.exponentActivityId;
-      Class.forName("host.exp.exponent.ReactNativeStaticHelpers").getMethod("reloadFromManifest", int.class).invoke(null, activityId);
+      Class.forName("host.exp.exponent.ReactNativeStaticHelpers").getMethod("reloadFromManifest", int.class).invoke(null, getExponentActivityId());
     } catch (Exception expoHandleErrorException) {
       expoHandleErrorException.printStackTrace();
+
+      // reloadExpoApp replaces handleReloadJS in some places
+      // where in Expo we would like to reload from manifest.
+      // If so, if anything goes wrong here, we can fall back
+      // to plain JS reload.
+      handleReloadJS();
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -486,52 +486,52 @@ public class DevSupportManagerImpl
             handleReloadJS();
           }
         });
-//    if (mDevSettings.isNuclideJSDebugEnabled()) {
-//      options.put(
-//          mApplicationContext.getString(R.string.reactandroid_catalyst_debug_nuclide),
-//          new DevOptionHandler() {
-//            @Override
-//            public void onOptionSelected() {
-//              mDevServerHelper.attachDebugger(mApplicationContext, "ReactNative");
-//            }
-//          });
-//    }
-// NOTE(brentvatne): This option does not make sense for Expo
-//    options.put(
-//        mApplicationContext.getString(R.string.reactandroid_catalyst_change_bundle_location),
-//        new DevOptionHandler() {
-//          @Override
-//          public void onOptionSelected() {
-//            Activity context = mReactInstanceManagerHelper.getCurrentActivity();
-//            if (context == null || context.isFinishing()) {
-//              FLog.e(
-//                  ReactConstants.TAG,
-//                  "Unable to launch change bundle location because react activity is not available");
-//              return;
-//            }
-//
-//            final EditText input = new EditText(context);
-//            input.setHint("localhost:8081");
-//
-//            AlertDialog bundleLocationDialog =
-//                new AlertDialog.Builder(context)
-//                    .setTitle(
-//                        mApplicationContext.getString(R.string.reactandroid_catalyst_change_bundle_location))
-//                    .setView(input)
-//                    .setPositiveButton(
-//                        android.R.string.ok,
-//                        new DialogInterface.OnClickListener() {
-//                          @Override
-//                          public void onClick(DialogInterface dialog, int which) {
-//                            String host = input.getText().toString();
-//                            mDevSettings.getPackagerConnectionSettings().setDebugServerHost(host);
-//                            handleReloadJS();
-//                          }
-//                        })
-//                    .create();
-//            bundleLocationDialog.show();
-//          }
-//      });
+    expo_transformer_remove: if (mDevSettings.isNuclideJSDebugEnabled()) {
+      options.put(
+          mApplicationContext.getString(R.string.reactandroid_catalyst_debug_nuclide),
+          new DevOptionHandler() {
+            @Override
+            public void onOptionSelected() {
+              mDevServerHelper.attachDebugger(mApplicationContext, "ReactNative");
+            }
+          });
+    }
+    // NOTE(brentvatne): This option does not make sense for Expo
+    expo_transformer_remove: options.put(
+        mApplicationContext.getString(R.string.reactandroid_catalyst_change_bundle_location),
+        new DevOptionHandler() {
+          @Override
+          public void onOptionSelected() {
+            Activity context = mReactInstanceManagerHelper.getCurrentActivity();
+            if (context == null || context.isFinishing()) {
+              FLog.e(
+                  ReactConstants.TAG,
+                  "Unable to launch change bundle location because react activity is not available");
+              return;
+            }
+
+            final EditText input = new EditText(context);
+            input.setHint("localhost:8081");
+
+            AlertDialog bundleLocationDialog =
+                new AlertDialog.Builder(context)
+                    .setTitle(
+                        mApplicationContext.getString(R.string.reactandroid_catalyst_change_bundle_location))
+                    .setView(input)
+                    .setPositiveButton(
+                        android.R.string.ok,
+                        new DialogInterface.OnClickListener() {
+                          @Override
+                          public void onClick(DialogInterface dialog, int which) {
+                            String host = input.getText().toString();
+                            mDevSettings.getPackagerConnectionSettings().setDebugServerHost(host);
+                            handleReloadJS();
+                          }
+                        })
+                    .create();
+            bundleLocationDialog.show();
+          }
+        });
     options.put(
         // NOTE: `isElementInspectorEnabled` is not guaranteed to be accurate.
         mApplicationContext.getString(R.string.reactandroid_catalyst_inspector),
@@ -561,28 +561,28 @@ public class DevSupportManagerImpl
                 mCurrentContext.getJSModule(HMRClient.class).disable();
               }
             }
-//            if (nextEnabled && !mDevSettings.isJSDevModeEnabled()) {
-//              Toast.makeText(
-//                      mApplicationContext,
-//                      mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading_auto_enable),
-//                      Toast.LENGTH_LONG)
-//                  .show();
-//              mDevSettings.setJSDevModeEnabled(true);
-//              handleReloadJS();
-//            }
+            expo_transformer_remove: if (nextEnabled && !mDevSettings.isJSDevModeEnabled()) {
+              Toast.makeText(
+                      mApplicationContext,
+                      mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading_auto_enable),
+                      Toast.LENGTH_LONG)
+                  .show();
+              mDevSettings.setJSDevModeEnabled(true);
+              handleReloadJS();
+            }
           }
         });
 
-//    options.put(
-//        mIsSamplingProfilerEnabled
-//            ? mApplicationContext.getString(R.string.reactandroid_catalyst_sample_profiler_disable)
-//            : mApplicationContext.getString(R.string.reactandroid_catalyst_sample_profiler_enable),
-//        new DevOptionHandler() {
-//          @Override
-//          public void onOptionSelected() {
-//            toggleJSSamplingProfiler();
-//          }
-//        });
+    expo_transformer_remove: options.put(
+        mIsSamplingProfilerEnabled
+            ? mApplicationContext.getString(R.string.reactandroid_catalyst_sample_profiler_disable)
+            : mApplicationContext.getString(R.string.reactandroid_catalyst_sample_profiler_enable),
+        new DevOptionHandler() {
+          @Override
+          public void onOptionSelected() {
+            toggleJSSamplingProfiler();
+          }
+        });
 
     options.put(
         mDevSettings.isFpsDebugEnabled()
@@ -603,16 +603,16 @@ public class DevSupportManagerImpl
             mDevSettings.setFpsDebugEnabled(!mDevSettings.isFpsDebugEnabled());
           }
         });
-//    options.put(
-//        mApplicationContext.getString(R.string.reactandroid_catalyst_settings),
-//        new DevOptionHandler() {
-//          @Override
-//          public void onOptionSelected() {
-//            Intent intent = new Intent(mApplicationContext, DevSettingsActivity.class);
-//            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-//            mApplicationContext.startActivity(intent);
-//          }
-//        });
+    expo_transformer_remove: options.put(
+        mApplicationContext.getString(R.string.reactandroid_catalyst_settings),
+        new DevOptionHandler() {
+          @Override
+          public void onOptionSelected() {
+            Intent intent = new Intent(mApplicationContext, DevSettingsActivity.class);
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            mApplicationContext.startActivity(intent);
+          }
+        });
 
     if (mCustomDevOptions.size() > 0) {
       options.putAll(mCustomDevOptions);

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -251,7 +251,6 @@ public class DevSupportManagerImpl
 
   @Override
   public void handleException(Exception e) {
-    try {
     if (mIsDevSupportEnabled) {
 
       for (ExceptionLogger logger : mExceptionLoggers) {
@@ -260,13 +259,6 @@ public class DevSupportManagerImpl
 
     } else {
       mDefaultNativeModuleCallExceptionHandler.handleException(e);
-    }
-    } catch (RuntimeException expoException) {
-      try {
-        Class.forName("host.exp.exponent.ReactNativeStaticHelpers").getMethod("handleReactNativeError", String.class, Object.class, Integer.class, Boolean.class).invoke(null, expoException.getMessage(), null, -1, true);
-      } catch (Exception expoHandleErrorException) {
-        expoHandleErrorException.printStackTrace();
-      }
     }
   }
 
@@ -765,27 +757,27 @@ public class DevSupportManagerImpl
    */
   @Override
   public boolean hasUpToDateJSBundleInCache() {
-//    if (mIsDevSupportEnabled && mJSBundleTempFile.exists()) {
-//      try {
-//        String packageName = mApplicationContext.getPackageName();
-//        PackageInfo thisPackage =
-//            mApplicationContext.getPackageManager().getPackageInfo(packageName, 0);
-//        if (mJSBundleTempFile.lastModified() > thisPackage.lastUpdateTime) {
-//          // Base APK has not been updated since we downloaded JS, but if app is using exopackage
-//          // it may only be a single dex that has been updated. We check for exopackage dir update
-//          // time in that case.
-//          File exopackageDir =
-//              new File(String.format(Locale.US, EXOPACKAGE_LOCATION_FORMAT, packageName));
-//          if (exopackageDir.exists()) {
-//            return mJSBundleTempFile.lastModified() > exopackageDir.lastModified();
-//          }
-//          return true;
-//        }
-//      } catch (PackageManager.NameNotFoundException e) {
-//        // Ignore this error and just fallback to loading JS from assets
-//        FLog.e(ReactConstants.TAG, "DevSupport is unable to get current app info");
-//      }
-//    }
+    if (mIsDevSupportEnabled && mJSBundleTempFile.exists()) {
+      try {
+        String packageName = mApplicationContext.getPackageName();
+        PackageInfo thisPackage =
+            mApplicationContext.getPackageManager().getPackageInfo(packageName, 0);
+        if (mJSBundleTempFile.lastModified() > thisPackage.lastUpdateTime) {
+          // Base APK has not been updated since we downloaded JS, but if app is using exopackage
+          // it may only be a single dex that has been updated. We check for exopackage dir update
+          // time in that case.
+          File exopackageDir =
+              new File(String.format(Locale.US, EXOPACKAGE_LOCATION_FORMAT, packageName));
+          if (exopackageDir.exists()) {
+            return mJSBundleTempFile.lastModified() > exopackageDir.lastModified();
+          }
+          return true;
+        }
+      } catch (PackageManager.NameNotFoundException e) {
+        // Ignore this error and just fallback to loading JS from assets
+        FLog.e(ReactConstants.TAG, "DevSupport is unable to get current app info");
+      }
+    }
     return false;
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -89,1042 +89,1197 @@ import java.util.concurrent.TimeoutException;
  * {@code <activity android:name="com.facebook.react.devsupport.DevSettingsActivity"/>}
  * {@code <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>}
  */
-public class DevSupportManagerImpl implements DevSupportManager, PackagerCommandListener, DevInternalSettings.Listener {
+public class DevSupportManagerImpl
+    implements DevSupportManager, PackagerCommandListener, DevInternalSettings.Listener {
 
-    public static int JAVA_ERROR_COOKIE = -1;
+  private static final int JAVA_ERROR_COOKIE = -1;
+  private static final int JSEXCEPTION_ERROR_COOKIE = -1;
+  private static final String JS_BUNDLE_FILE_NAME = "ReactNativeDevBundle.js";
+  private static final String RELOAD_APP_ACTION_SUFFIX = ".RELOAD_APP_ACTION";
+  private boolean mIsSamplingProfilerEnabled = false;
 
-    public static int JSEXCEPTION_ERROR_COOKIE = -1;
+  private enum ErrorType {
+    JS,
+    NATIVE
+  }
 
-    public static String JS_BUNDLE_FILE_NAME = "ReactNativeDevBundle.js";
+  private static final String EXOPACKAGE_LOCATION_FORMAT =
+      "/data/local/tmp/exopackage/%s//secondary-dex";
 
-    public static String RELOAD_APP_ACTION_SUFFIX = ".RELOAD_APP_ACTION";
+  public static String EMOJI_HUNDRED_POINTS_SYMBOL = " 💯";
+  public static String EMOJI_FACE_WITH_NO_GOOD_GESTURE = " 🙅";
 
-    public boolean mIsSamplingProfilerEnabled = false;
+  private final List<ExceptionLogger> mExceptionLoggers = new ArrayList<>();
 
-    private enum ErrorType {
+  private final Context mApplicationContext;
+  private final ShakeDetector mShakeDetector;
+  private final BroadcastReceiver mReloadAppBroadcastReceiver;
+  private final DevServerHelper mDevServerHelper;
+  private final LinkedHashMap<String, DevOptionHandler> mCustomDevOptions = new LinkedHashMap<>();
+  private final ReactInstanceManagerDevHelper mReactInstanceManagerHelper;
+  private final @Nullable String mJSAppBundleName;
+  private final File mJSBundleTempFile;
+  private final DefaultNativeModuleCallExceptionHandler mDefaultNativeModuleCallExceptionHandler;
+  private final DevLoadingViewController mDevLoadingViewController;
 
-        JS, NATIVE
-    }
+  private @Nullable RedBoxDialog mRedBoxDialog;
+  private @Nullable AlertDialog mDevOptionsDialog;
+  private @Nullable DebugOverlayController mDebugOverlayController;
+  private boolean mDevLoadingViewVisible = false;
+  private @Nullable ReactContext mCurrentContext;
+  private DevInternalSettings mDevSettings;
+  private boolean mIsReceiverRegistered = false;
+  private boolean mIsShakeDetectorStarted = false;
+  private boolean mIsDevSupportEnabled = false;
+  private @Nullable RedBoxHandler mRedBoxHandler;
+  private @Nullable String mLastErrorTitle;
+  private @Nullable StackFrame[] mLastErrorStack;
+  private int mLastErrorCookie = 0;
+  private @Nullable ErrorType mLastErrorType;
+  private @Nullable DevBundleDownloadListener mBundleDownloadListener;
+  private @Nullable List<ErrorCustomizer> mErrorCustomizers;
 
-    public static String EXOPACKAGE_LOCATION_FORMAT = "/data/local/tmp/exopackage/%s//secondary-dex";
+  private InspectorPackagerConnection.BundleStatus mBundleStatus;
 
-    public static String EMOJI_HUNDRED_POINTS_SYMBOL = " 💯";
+  private @Nullable Map<String, RequestHandler> mCustomPackagerCommandHandlers;
 
-    public static String EMOJI_FACE_WITH_NO_GOOD_GESTURE = " 🙅";
+  public DevSupportManagerImpl(
+      Context applicationContext,
+      ReactInstanceManagerDevHelper reactInstanceManagerHelper,
+      @Nullable String packagerPathForJSBundleName,
+      boolean enableOnCreate,
+      int minNumShakes) {
 
-    public final List<ExceptionLogger> mExceptionLoggers = new ArrayList<>();
+    this(
+        applicationContext,
+        reactInstanceManagerHelper,
+        packagerPathForJSBundleName,
+        enableOnCreate,
+        null,
+        null,
+        minNumShakes,
+        null);
+  }
 
-    public final Context mApplicationContext;
-
-    public final ShakeDetector mShakeDetector;
-
-    public final BroadcastReceiver mReloadAppBroadcastReceiver;
-
-    public final DevServerHelper mDevServerHelper;
-
-    public final LinkedHashMap<String, DevOptionHandler> mCustomDevOptions = new LinkedHashMap<>();
-
-    public final ReactInstanceManagerDevHelper mReactInstanceManagerHelper;
-
-    @Nullable
-    public final String mJSAppBundleName;
-
-    public final File mJSBundleTempFile;
-
-    public final DefaultNativeModuleCallExceptionHandler mDefaultNativeModuleCallExceptionHandler;
-
-    public final DevLoadingViewController mDevLoadingViewController;
-
-    @Nullable
-    public RedBoxDialog mRedBoxDialog;
-
-    @Nullable
-    public AlertDialog mDevOptionsDialog;
-
-    @Nullable
-    public DebugOverlayController mDebugOverlayController;
-
-    public boolean mDevLoadingViewVisible = false;
-
-    @Nullable
-    public ReactContext mCurrentContext;
-
-    public DevInternalSettings mDevSettings;
-
-    public boolean mIsReceiverRegistered = false;
-
-    public boolean mIsShakeDetectorStarted = false;
-
-    public boolean mIsDevSupportEnabled = false;
-
-    @Nullable
-    public RedBoxHandler mRedBoxHandler;
-
-    @Nullable
-    public String mLastErrorTitle;
-
-    @Nullable
-    public StackFrame[] mLastErrorStack;
-
-    public int mLastErrorCookie = 0;
-
-    @Nullable
-    public ErrorType mLastErrorType;
-
-    @Nullable
-    public DevBundleDownloadListener mBundleDownloadListener;
-
-    @Nullable
-    public List<ErrorCustomizer> mErrorCustomizers;
-
-    public InspectorPackagerConnection.BundleStatus mBundleStatus;
-
-    @Nullable
-    public Map<String, RequestHandler> mCustomPackagerCommandHandlers;
-
-    public DevSupportManagerImpl(Context applicationContext, ReactInstanceManagerDevHelper reactInstanceManagerHelper, @Nullable String packagerPathForJSBundleName, boolean enableOnCreate, int minNumShakes) {
-        this(applicationContext, reactInstanceManagerHelper, packagerPathForJSBundleName, enableOnCreate, null, null, minNumShakes, null);
-    }
-
-    public DevSupportManagerImpl(Context applicationContext, ReactInstanceManagerDevHelper reactInstanceManagerHelper, @Nullable String packagerPathForJSBundleName, boolean enableOnCreate, @Nullable RedBoxHandler redBoxHandler, @Nullable DevBundleDownloadListener devBundleDownloadListener, int minNumShakes, @Nullable Map<String, RequestHandler> customPackagerCommandHandlers) {
-        mReactInstanceManagerHelper = reactInstanceManagerHelper;
-        mApplicationContext = applicationContext;
-        mJSAppBundleName = packagerPathForJSBundleName;
-        mDevSettings = new DevInternalSettings(applicationContext, this);
-        mBundleStatus = new InspectorPackagerConnection.BundleStatus();
-        mDevServerHelper = new DevServerHelper(mDevSettings, mApplicationContext.getPackageName(), new InspectorPackagerConnection.BundleStatusProvider() {
-
-            @Override
-            public InspectorPackagerConnection.BundleStatus getBundleStatus() {
+  public DevSupportManagerImpl(
+      Context applicationContext,
+      ReactInstanceManagerDevHelper reactInstanceManagerHelper,
+      @Nullable String packagerPathForJSBundleName,
+      boolean enableOnCreate,
+      @Nullable RedBoxHandler redBoxHandler,
+      @Nullable DevBundleDownloadListener devBundleDownloadListener,
+      int minNumShakes,
+      @Nullable Map<String, RequestHandler> customPackagerCommandHandlers) {
+    mReactInstanceManagerHelper = reactInstanceManagerHelper;
+    mApplicationContext = applicationContext;
+    mJSAppBundleName = packagerPathForJSBundleName;
+    mDevSettings = new DevInternalSettings(applicationContext, this);
+    mBundleStatus = new InspectorPackagerConnection.BundleStatus();
+    mDevServerHelper =
+        new DevServerHelper(
+            mDevSettings,
+            mApplicationContext.getPackageName(),
+            new InspectorPackagerConnection.BundleStatusProvider() {
+              @Override
+              public InspectorPackagerConnection.BundleStatus getBundleStatus() {
                 return mBundleStatus;
-            }
-        });
-        mBundleDownloadListener = devBundleDownloadListener;
-        // Prepare shake gesture detector (will be started/stopped from #reload)
-        mShakeDetector = new ShakeDetector(new ShakeDetector.ShakeListener() {
+              }
+            });
+    mBundleDownloadListener = devBundleDownloadListener;
 
-            @Override
-            public void onShake() {
+    // Prepare shake gesture detector (will be started/stopped from #reload)
+    mShakeDetector =
+        new ShakeDetector(
+            new ShakeDetector.ShakeListener() {
+              @Override
+              public void onShake() {
                 showDevOptionsDialog();
-            }
-        }, minNumShakes);
-        mCustomPackagerCommandHandlers = customPackagerCommandHandlers;
-        // Prepare reload APP broadcast receiver (will be registered/unregistered from #reload)
-        mReloadAppBroadcastReceiver = new BroadcastReceiver() {
+              }
+            },
+            minNumShakes);
 
-            @Override
-            public void onReceive(Context context, Intent intent) {
-                String action = intent.getAction();
-                if (getReloadAppAction(context).equals(action)) {
-                    if (intent.getBooleanExtra(DevServerHelper.RELOAD_APP_EXTRA_JS_PROXY, false)) {
-                        mDevSettings.setRemoteJSDebugEnabled(true);
-                        mDevServerHelper.launchJSDevtools();
-                    } else {
-                        mDevSettings.setRemoteJSDebugEnabled(false);
-                    }
-                    handleReloadJS();
-                }
+    mCustomPackagerCommandHandlers = customPackagerCommandHandlers;
+
+    // Prepare reload APP broadcast receiver (will be registered/unregistered from #reload)
+    mReloadAppBroadcastReceiver =
+        new BroadcastReceiver() {
+          @Override
+          public void onReceive(Context context, Intent intent) {
+            String action = intent.getAction();
+            if (getReloadAppAction(context).equals(action)) {
+              if (intent.getBooleanExtra(DevServerHelper.RELOAD_APP_EXTRA_JS_PROXY, false)) {
+                mDevSettings.setRemoteJSDebugEnabled(true);
+                mDevServerHelper.launchJSDevtools();
+              } else {
+                mDevSettings.setRemoteJSDebugEnabled(false);
+              }
+              handleReloadJS();
             }
+          }
         };
-        // We store JS bundle loaded from dev server in a single destination in app's data dir.
-        // In case when someone schedule 2 subsequent reloads it may happen that JS thread will
-        // start reading first reload output while the second reload starts writing to the same
-        // file. As this should only be the case in dev mode we leave it as it is.
-        // TODO(6418010): Fix readers-writers problem in debug reload from HTTP server
-        mJSBundleTempFile = new File(applicationContext.getFilesDir(), JS_BUNDLE_FILE_NAME);
-        mDefaultNativeModuleCallExceptionHandler = new DefaultNativeModuleCallExceptionHandler();
-        setDevSupportEnabled(enableOnCreate);
-        mRedBoxHandler = redBoxHandler;
-        mDevLoadingViewController = new DevLoadingViewController(applicationContext, reactInstanceManagerHelper);
-        mExceptionLoggers.add(new JSExceptionLogger());
-        if (mDevSettings.isStartSamplingProfilerOnInit()) {
-            // Only start the profiler. If its already running, there is an error
-            if (!mIsSamplingProfilerEnabled) {
-                toggleJSSamplingProfiler();
-            } else {
-                Toast.makeText(mApplicationContext, "JS Sampling Profiler was already running, so did not start the sampling profiler", Toast.LENGTH_LONG).show();
-            }
-        }
+
+    // We store JS bundle loaded from dev server in a single destination in app's data dir.
+    // In case when someone schedule 2 subsequent reloads it may happen that JS thread will
+    // start reading first reload output while the second reload starts writing to the same
+    // file. As this should only be the case in dev mode we leave it as it is.
+    // TODO(6418010): Fix readers-writers problem in debug reload from HTTP server
+    mJSBundleTempFile = new File(applicationContext.getFilesDir(), JS_BUNDLE_FILE_NAME);
+
+    mDefaultNativeModuleCallExceptionHandler = new DefaultNativeModuleCallExceptionHandler();
+
+    setDevSupportEnabled(enableOnCreate);
+
+    mRedBoxHandler = redBoxHandler;
+    mDevLoadingViewController =
+        new DevLoadingViewController(applicationContext, reactInstanceManagerHelper);
+
+    mExceptionLoggers.add(new JSExceptionLogger());
+
+    if (mDevSettings.isStartSamplingProfilerOnInit()) {
+      // Only start the profiler. If its already running, there is an error
+      if (!mIsSamplingProfilerEnabled) {
+        toggleJSSamplingProfiler();
+      } else {
+        Toast.makeText(
+                mApplicationContext,
+                "JS Sampling Profiler was already running, so did not start the sampling profiler",
+                Toast.LENGTH_LONG)
+            .show();
+      }
     }
+  }
 
-    @Override
-    public void handleException(Exception e) {
-        try {
-            if (mIsDevSupportEnabled) {
-                for (ExceptionLogger logger : mExceptionLoggers) {
-                    logger.log(e);
-                }
-            } else {
-                mDefaultNativeModuleCallExceptionHandler.handleException(e);
-            }
-        } catch (RuntimeException expoException) {
-            try {
-                Class.forName("host.exp.exponent.ReactNativeStaticHelpers").getMethod("handleReactNativeError", String.class, Object.class, Integer.class, Boolean.class).invoke(null, expoException.getMessage(), null, -1, true);
-            } catch (Exception expoHandleErrorException) {
-                expoHandleErrorException.printStackTrace();
-            }
-        }
+  @Override
+  public void handleException(Exception e) {
+    try {
+    if (mIsDevSupportEnabled) {
+
+      for (ExceptionLogger logger : mExceptionLoggers) {
+        logger.log(e);
+      }
+
+    } else {
+      mDefaultNativeModuleCallExceptionHandler.handleException(e);
     }
-
-    private interface ExceptionLogger {
-
-        void log(Exception ex);
-    }
-
-    private class JSExceptionLogger implements ExceptionLogger {
-
-        @Override
-        public void log(Exception e) {
-            StringBuilder message = new StringBuilder(e.getMessage() == null ? "Exception in native call from JS" : e.getMessage());
-            Throwable cause = e.getCause();
-            while (cause != null) {
-                message.append("\n\n").append(cause.getMessage());
-                cause = cause.getCause();
-            }
-            if (e instanceof JSException) {
-                FLog.e(ReactConstants.TAG, "Exception in native call from JS", e);
-                String stack = ((JSException) e).getStack();
-                message.append("\n\n").append(stack);
-                // TODO #11638796: convert the stack into something useful
-                showNewError(message.toString(), new StackFrame[] {}, JSEXCEPTION_ERROR_COOKIE, ErrorType.JS);
-            } else {
-                showNewJavaError(message.toString(), e);
-            }
-        }
-    }
-
-    @Override
-    public void showNewJavaError(@Nullable String message, Throwable e) {
-        FLog.e(ReactConstants.TAG, "Exception in native call", e);
-        showNewError(message, StackTraceHelper.convertJavaStackTrace(e), JAVA_ERROR_COOKIE, ErrorType.NATIVE);
-    }
-
-    /**
-   * Add option item to dev settings dialog displayed by this manager. In the case user select given
-   * option from that dialog, the appropriate handler passed as {@param optionHandler} will be
-   * called.
-   */
-    @Override
-    public void addCustomDevOption(String optionName, DevOptionHandler optionHandler) {
-        mCustomDevOptions.put(optionName, optionHandler);
-    }
-
-    @Override
-    public void showNewJSError(String message, ReadableArray details, int errorCookie) {
-        showNewError(message, StackTraceHelper.convertJsStackTrace(details), errorCookie, ErrorType.JS);
-    }
-
-    @Override
-    public void registerErrorCustomizer(ErrorCustomizer errorCustomizer) {
-        if (mErrorCustomizers == null) {
-            mErrorCustomizers = new ArrayList<>();
-        }
-        mErrorCustomizers.add(errorCustomizer);
-    }
-
-    private Pair<String, StackFrame[]> processErrorCustomizers(Pair<String, StackFrame[]> errorInfo) {
-        if (mErrorCustomizers == null) {
-            return errorInfo;
-        } else {
-            for (ErrorCustomizer errorCustomizer : mErrorCustomizers) {
-                Pair<String, StackFrame[]> result = errorCustomizer.customizeErrorInfo(errorInfo);
-                if (result != null) {
-                    errorInfo = result;
-                }
-            }
-            return errorInfo;
-        }
-    }
-
-    @Override
-    public void updateJSError(final String message, final ReadableArray details, final int errorCookie) {
-        UiThreadUtil.runOnUiThread(new Runnable() {
-
-            @Override
-            public void run() {
-                // belongs to the most recent showNewJSError
-                if (mRedBoxDialog == null || !mRedBoxDialog.isShowing() || errorCookie != mLastErrorCookie) {
-                    return;
-                }
-                StackFrame[] stack = StackTraceHelper.convertJsStackTrace(details);
-                Pair<String, StackFrame[]> errorInfo = processErrorCustomizers(Pair.create(message, stack));
-                mRedBoxDialog.setExceptionDetails(errorInfo.first, errorInfo.second);
-                updateLastErrorInfo(message, stack, errorCookie, ErrorType.JS);
-                // JS errors are reported here after source mapping.
-                if (mRedBoxHandler != null) {
-                    mRedBoxHandler.handleRedbox(message, stack, RedBoxHandler.ErrorType.JS);
-                    mRedBoxDialog.resetReporting();
-                }
-                mRedBoxDialog.show();
-            }
-        });
-    }
-
-    @Override
-    public void hideRedboxDialog() {
-        // dismiss redbox if exists
-        if (mRedBoxDialog != null) {
-            mRedBoxDialog.dismiss();
-            mRedBoxDialog = null;
-        }
-    }
-
-    private void hideDevOptionsDialog() {
-        if (mDevOptionsDialog != null) {
-            mDevOptionsDialog.dismiss();
-            mDevOptionsDialog = null;
-        }
-    }
-
-    private void showNewError(@Nullable final String message, final StackFrame[] stack, final int errorCookie, final ErrorType errorType) {
-        UiThreadUtil.runOnUiThread(new Runnable() {
-
-            @Override
-            public void run() {
-                if (mRedBoxDialog == null) {
-                    Activity context = mReactInstanceManagerHelper.getCurrentActivity();
-                    if (context == null || context.isFinishing()) {
-                        FLog.e(ReactConstants.TAG, "Unable to launch redbox because react activity " + "is not available, here is the error that redbox would've displayed: " + message);
-                        return;
-                    }
-                    mRedBoxDialog = new RedBoxDialog(context, DevSupportManagerImpl.this, mRedBoxHandler);
-                }
-                if (mRedBoxDialog.isShowing()) {
-                    // show the first and most actionable one.
-                    return;
-                }
-                Pair<String, StackFrame[]> errorInfo = processErrorCustomizers(Pair.create(message, stack));
-                mRedBoxDialog.setExceptionDetails(errorInfo.first, errorInfo.second);
-                updateLastErrorInfo(message, stack, errorCookie, errorType);
-                // inside {@link #updateJSError} after source mapping.
-                if (mRedBoxHandler != null && errorType == ErrorType.NATIVE) {
-                    mRedBoxHandler.handleRedbox(message, stack, RedBoxHandler.ErrorType.NATIVE);
-                }
-                mRedBoxDialog.resetReporting();
-                mRedBoxDialog.show();
-            }
-        });
-    }
-
-    @Override
-    public void reloadExpoApp() {
+    } catch (RuntimeException expoException) {
       try {
-        int activityId = mDevServerHelper.mSettings.exponentActivityId;
-        Class.forName("host.exp.exponent.ReactNativeStaticHelpers").getMethod("reloadFromManifest", int.class).invoke(null, activityId);
+        Class.forName("host.exp.exponent.ReactNativeStaticHelpers").getMethod("handleReactNativeError", String.class, Object.class, Integer.class, Boolean.class).invoke(null, expoException.getMessage(), null, -1, true);
       } catch (Exception expoHandleErrorException) {
         expoHandleErrorException.printStackTrace();
       }
     }
+  }
 
+  private interface ExceptionLogger {
+    void log(Exception ex);
+  }
+
+  private class JSExceptionLogger implements ExceptionLogger {
 
     @Override
-    public void showDevOptionsDialog() {
-        if (mDevOptionsDialog != null || !mIsDevSupportEnabled || ActivityManager.isUserAMonkey()) {
-            return;
+    public void log(Exception e) {
+      StringBuilder message =
+          new StringBuilder(
+              e.getMessage() == null ? "Exception in native call from JS" : e.getMessage());
+      Throwable cause = e.getCause();
+      while (cause != null) {
+        message.append("\n\n").append(cause.getMessage());
+        cause = cause.getCause();
+      }
+
+      if (e instanceof JSException) {
+        FLog.e(ReactConstants.TAG, "Exception in native call from JS", e);
+        String stack = ((JSException) e).getStack();
+        message.append("\n\n").append(stack);
+
+        // TODO #11638796: convert the stack into something useful
+        showNewError(
+            message.toString(), new StackFrame[] {}, JSEXCEPTION_ERROR_COOKIE, ErrorType.JS);
+      } else {
+        showNewJavaError(message.toString(), e);
+      }
+    }
+  }
+
+  @Override
+  public void showNewJavaError(@Nullable String message, Throwable e) {
+    FLog.e(ReactConstants.TAG, "Exception in native call", e);
+    showNewError(
+        message, StackTraceHelper.convertJavaStackTrace(e), JAVA_ERROR_COOKIE, ErrorType.NATIVE);
+  }
+
+  /**
+   * Add option item to dev settings dialog displayed by this manager. In the case user select given
+   * option from that dialog, the appropriate handler passed as {@param optionHandler} will be
+   * called.
+   */
+  @Override
+  public void addCustomDevOption(String optionName, DevOptionHandler optionHandler) {
+    mCustomDevOptions.put(optionName, optionHandler);
+  }
+
+  @Override
+  public void showNewJSError(String message, ReadableArray details, int errorCookie) {
+    showNewError(message, StackTraceHelper.convertJsStackTrace(details), errorCookie, ErrorType.JS);
+  }
+
+  @Override
+  public void registerErrorCustomizer(ErrorCustomizer errorCustomizer) {
+    if (mErrorCustomizers == null) {
+      mErrorCustomizers = new ArrayList<>();
+    }
+    mErrorCustomizers.add(errorCustomizer);
+  }
+
+  private Pair<String, StackFrame[]> processErrorCustomizers(Pair<String, StackFrame[]> errorInfo) {
+    if (mErrorCustomizers == null) {
+      return errorInfo;
+    } else {
+      for (ErrorCustomizer errorCustomizer : mErrorCustomizers) {
+        Pair<String, StackFrame[]> result = errorCustomizer.customizeErrorInfo(errorInfo);
+        if (result != null) {
+          errorInfo = result;
         }
-        LinkedHashMap<String, DevOptionHandler> options = new LinkedHashMap<>();
-        /* register standard options */
-        options.put(mApplicationContext.getString(R.string.reactandroid_catalyst_reload), new DevOptionHandler() {
+      }
+      return errorInfo;
+    }
+  }
 
-            @Override
-            public void onOptionSelected() {
-                if (!mDevSettings.isJSDevModeEnabled() && mDevSettings.isHotModuleReplacementEnabled()) {
-                    Toast.makeText(mApplicationContext, mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading_auto_disable), Toast.LENGTH_LONG).show();
-                    mDevSettings.setHotModuleReplacementEnabled(false);
-                }
-
-                // NOTE(brentvatne): rather than reload just JS we need to reload the entire project from manifest
-                // handleReloadJS();
-                reloadExpoApp();
+  @Override
+  public void updateJSError(
+      final String message, final ReadableArray details, final int errorCookie) {
+    UiThreadUtil.runOnUiThread(
+        new Runnable() {
+          @Override
+          public void run() {
+            // Since we only show the first JS error in a succession of JS errors, make sure we only
+            // update the error message for that error message. This assumes that updateJSError
+            // belongs to the most recent showNewJSError
+            if (mRedBoxDialog == null
+                || !mRedBoxDialog.isShowing()
+                || errorCookie != mLastErrorCookie) {
+              return;
             }
+            StackFrame[] stack = StackTraceHelper.convertJsStackTrace(details);
+            Pair<String, StackFrame[]> errorInfo =
+                processErrorCustomizers(Pair.create(message, stack));
+            mRedBoxDialog.setExceptionDetails(errorInfo.first, errorInfo.second);
+            updateLastErrorInfo(message, stack, errorCookie, ErrorType.JS);
+            // JS errors are reported here after source mapping.
+            if (mRedBoxHandler != null) {
+              mRedBoxHandler.handleRedbox(message, stack, RedBoxHandler.ErrorType.JS);
+              mRedBoxDialog.resetReporting();
+            }
+            mRedBoxDialog.show();
+          }
         });
+  }
 
-//        if (mDevSettings.isNuclideJSDebugEnabled()) {
-//            options.put(mApplicationContext.getString(R.string.reactandroid_catalyst_debug_nuclide), new DevOptionHandler() {
-//
-//                @Override
-//                public void onOptionSelected() {
-//                    mDevServerHelper.attachDebugger(mApplicationContext, "ReactNative");
-//                }
-//            });
-//        }
+  @Override
+  public void hideRedboxDialog() {
+    // dismiss redbox if exists
+    if (mRedBoxDialog != null) {
+      mRedBoxDialog.dismiss();
+      mRedBoxDialog = null;
+    }
+  }
 
-        // NOTE(brentvatne): This option does not make sense for Expo
-//        options.put(mApplicationContext.getString(R.string.reactandroid_catalyst_change_bundle_location), new DevOptionHandler() {
-//
+  private void hideDevOptionsDialog() {
+    if (mDevOptionsDialog != null) {
+      mDevOptionsDialog.dismiss();
+      mDevOptionsDialog = null;
+    }
+  }
+
+  private void showNewError(
+      @Nullable final String message,
+      final StackFrame[] stack,
+      final int errorCookie,
+      final ErrorType errorType) {
+    UiThreadUtil.runOnUiThread(
+        new Runnable() {
+          @Override
+          public void run() {
+            if (mRedBoxDialog == null) {
+              Activity context = mReactInstanceManagerHelper.getCurrentActivity();
+              if (context == null || context.isFinishing()) {
+                FLog.e(
+                    ReactConstants.TAG,
+                    "Unable to launch redbox because react activity "
+                        + "is not available, here is the error that redbox would've displayed: "
+                        + message);
+                return;
+              }
+              mRedBoxDialog = new RedBoxDialog(context, DevSupportManagerImpl.this, mRedBoxHandler);
+            }
+            if (mRedBoxDialog.isShowing()) {
+              // Sometimes errors cause multiple errors to be thrown in JS in quick succession. Only
+              // show the first and most actionable one.
+              return;
+            }
+            Pair<String, StackFrame[]> errorInfo =
+                processErrorCustomizers(Pair.create(message, stack));
+            mRedBoxDialog.setExceptionDetails(errorInfo.first, errorInfo.second);
+            updateLastErrorInfo(message, stack, errorCookie, errorType);
+            // Only report native errors here. JS errors are reported
+            // inside {@link #updateJSError} after source mapping.
+            if (mRedBoxHandler != null && errorType == ErrorType.NATIVE) {
+              mRedBoxHandler.handleRedbox(message, stack, RedBoxHandler.ErrorType.NATIVE);
+            }
+            mRedBoxDialog.resetReporting();
+            mRedBoxDialog.show();
+          }
+        });
+  }
+
+  @Override
+  public void reloadExpoApp() {
+    try {
+      int activityId = mDevServerHelper.mSettings.exponentActivityId;
+      Class.forName("host.exp.exponent.ReactNativeStaticHelpers").getMethod("reloadFromManifest", int.class).invoke(null, activityId);
+    } catch (Exception expoHandleErrorException) {
+      expoHandleErrorException.printStackTrace();
+    }
+  }
+
+
+  @Override
+  public void showDevOptionsDialog() {
+    if (mDevOptionsDialog != null || !mIsDevSupportEnabled || ActivityManager.isUserAMonkey()) {
+      return;
+    }
+    LinkedHashMap<String, DevOptionHandler> options = new LinkedHashMap<>();
+    /* register standard options */
+    options.put(
+        mApplicationContext.getString(R.string.reactandroid_catalyst_reload),
+        new DevOptionHandler() {
+          @Override
+          public void onOptionSelected() {
+            if (!mDevSettings.isJSDevModeEnabled()
+                && mDevSettings.isHotModuleReplacementEnabled()) {
+              Toast.makeText(
+                      mApplicationContext,
+                      mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading_auto_disable),
+                      Toast.LENGTH_LONG)
+                  .show();
+              mDevSettings.setHotModuleReplacementEnabled(false);
+            }
+
+            // NOTE(brentvatne): rather than reload just JS we need to reload the entire project from manifest
+            // handleReloadJS();
+            reloadExpoApp();
+          }
+        });
+    options.put(
+        mDevSettings.isNuclideJSDebugEnabled()
+            ? mDevSettings.isRemoteJSDebugEnabled()
+                ? mApplicationContext.getString(R.string.reactandroid_catalyst_debug_chrome_stop)
+                : mApplicationContext.getString(R.string.reactandroid_catalyst_debug_chrome)
+            : mDevSettings.isRemoteJSDebugEnabled()
+                ? mApplicationContext.getString(R.string.reactandroid_catalyst_debug_stop)
+                : mApplicationContext.getString(R.string.reactandroid_catalyst_debug),
+        new DevOptionHandler() {
+          @Override
+          public void onOptionSelected() {
+            mDevSettings.setRemoteJSDebugEnabled(!mDevSettings.isRemoteJSDebugEnabled());
+            handleReloadJS();
+          }
+        });
+//    if (mDevSettings.isNuclideJSDebugEnabled()) {
+//      options.put(
+//          mApplicationContext.getString(R.string.reactandroid_catalyst_debug_nuclide),
+//          new DevOptionHandler() {
 //            @Override
 //            public void onOptionSelected() {
-//                Activity context = mReactInstanceManagerHelper.getCurrentActivity();
-//                if (context == null || context.isFinishing()) {
-//                    FLog.e(ReactConstants.TAG, "Unable to launch change bundle location because react activity is not available");
-//                    return;
-//                }
-//                final EditText input = new EditText(context);
-//                input.setHint("localhost:8081");
-//                AlertDialog bundleLocationDialog = new AlertDialog.Builder(context).setTitle(mApplicationContext.getString(R.string.reactandroid_catalyst_change_bundle_location)).setView(input).setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
-//
-//                    @Override
-//                    public void onClick(DialogInterface dialog, int which) {
-//                        String host = input.getText().toString();
-//                        mDevSettings.getPackagerConnectionSettings().setDebugServerHost(host);
-//                        handleReloadJS();
-//                    }
-//                }).create();
-//                bundleLocationDialog.show();
+//              mDevServerHelper.attachDebugger(mApplicationContext, "ReactNative");
 //            }
-//        });
-
-        // "Live reload" which refreshes on every edit was removed in favor of "Fast Refresh".
-        // While native code for "Live reload" is still there, please don't add the option back.
-        // See D15958697 for more context.
-        options.put(mDevSettings.isHotModuleReplacementEnabled() ? mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading_stop) : mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading), new DevOptionHandler() {
-
-            @Override
-            public void onOptionSelected() {
-                boolean nextEnabled = !mDevSettings.isHotModuleReplacementEnabled();
-                mDevSettings.setHotModuleReplacementEnabled(nextEnabled);
-                if (mCurrentContext != null) {
-                    if (nextEnabled) {
-                        mCurrentContext.getJSModule(HMRClient.class).enable();
-                    } else {
-                        mCurrentContext.getJSModule(HMRClient.class).disable();
-                    }
-                }
-//                if (nextEnabled && !mDevSettings.isJSDevModeEnabled()) {
-//                    Toast.makeText(mApplicationContext, mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading_auto_enable), Toast.LENGTH_LONG).show();
-//                    mDevSettings.setJSDevModeEnabled(true);
-//                    handleReloadJS();
-//                }
+//          });
+//    }
+// NOTE(brentvatne): This option does not make sense for Expo
+//    options.put(
+//        mApplicationContext.getString(R.string.reactandroid_catalyst_change_bundle_location),
+//        new DevOptionHandler() {
+//          @Override
+//          public void onOptionSelected() {
+//            Activity context = mReactInstanceManagerHelper.getCurrentActivity();
+//            if (context == null || context.isFinishing()) {
+//              FLog.e(
+//                  ReactConstants.TAG,
+//                  "Unable to launch change bundle location because react activity is not available");
+//              return;
+//            }
+//
+//            final EditText input = new EditText(context);
+//            input.setHint("localhost:8081");
+//
+//            AlertDialog bundleLocationDialog =
+//                new AlertDialog.Builder(context)
+//                    .setTitle(
+//                        mApplicationContext.getString(R.string.reactandroid_catalyst_change_bundle_location))
+//                    .setView(input)
+//                    .setPositiveButton(
+//                        android.R.string.ok,
+//                        new DialogInterface.OnClickListener() {
+//                          @Override
+//                          public void onClick(DialogInterface dialog, int which) {
+//                            String host = input.getText().toString();
+//                            mDevSettings.getPackagerConnectionSettings().setDebugServerHost(host);
+//                            handleReloadJS();
+//                          }
+//                        })
+//                    .create();
+//            bundleLocationDialog.show();
+//          }
+//      });
+    options.put(
+        // NOTE: `isElementInspectorEnabled` is not guaranteed to be accurate.
+        mApplicationContext.getString(R.string.reactandroid_catalyst_inspector),
+        new DevOptionHandler() {
+          @Override
+          public void onOptionSelected() {
+            mDevSettings.setElementInspectorEnabled(!mDevSettings.isElementInspectorEnabled());
+            mReactInstanceManagerHelper.toggleElementInspector();
+          }
+        });
+    // "Live reload" which refreshes on every edit was removed in favor of "Fast Refresh".
+    // While native code for "Live reload" is still there, please don't add the option back.
+    // See D15958697 for more context.
+    options.put(
+        mDevSettings.isHotModuleReplacementEnabled()
+            ? mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading_stop)
+            : mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading),
+        new DevOptionHandler() {
+          @Override
+          public void onOptionSelected() {
+            boolean nextEnabled = !mDevSettings.isHotModuleReplacementEnabled();
+            mDevSettings.setHotModuleReplacementEnabled(nextEnabled);
+            if (mCurrentContext != null) {
+              if (nextEnabled) {
+                mCurrentContext.getJSModule(HMRClient.class).enable();
+              } else {
+                mCurrentContext.getJSModule(HMRClient.class).disable();
+              }
             }
+//            if (nextEnabled && !mDevSettings.isJSDevModeEnabled()) {
+//              Toast.makeText(
+//                      mApplicationContext,
+//                      mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading_auto_enable),
+//                      Toast.LENGTH_LONG)
+//                  .show();
+//              mDevSettings.setJSDevModeEnabled(true);
+//              handleReloadJS();
+//            }
+          }
         });
 
-
-      options.put(mDevSettings.isNuclideJSDebugEnabled() ? mDevSettings.isRemoteJSDebugEnabled() ? mApplicationContext.getString(R.string.reactandroid_catalyst_debug_chrome_stop) : mApplicationContext.getString(R.string.reactandroid_catalyst_debug_chrome) : mDevSettings.isRemoteJSDebugEnabled() ? mApplicationContext.getString(R.string.reactandroid_catalyst_debug_stop) : mApplicationContext.getString(R.string.reactandroid_catalyst_debug), new DevOptionHandler() {
-
-        @Override
-        public void onOptionSelected() {
-          mDevSettings.setRemoteJSDebugEnabled(!mDevSettings.isRemoteJSDebugEnabled());
-          handleReloadJS();
-        }
-      });
-
-
-
-//        options.put(mIsSamplingProfilerEnabled ? mApplicationContext.getString(R.string.reactandroid_catalyst_sample_profiler_disable) : mApplicationContext.getString(R.string.reactandroid_catalyst_sample_profiler_enable), new DevOptionHandler() {
-//
-//            @Override
-//            public void onOptionSelected() {
-//                toggleJSSamplingProfiler();
-//            }
+//    options.put(
+//        mIsSamplingProfilerEnabled
+//            ? mApplicationContext.getString(R.string.reactandroid_catalyst_sample_profiler_disable)
+//            : mApplicationContext.getString(R.string.reactandroid_catalyst_sample_profiler_enable),
+//        new DevOptionHandler() {
+//          @Override
+//          public void onOptionSelected() {
+//            toggleJSSamplingProfiler();
+//          }
 //        });
-        options.put(mDevSettings.isFpsDebugEnabled() ? mApplicationContext.getString(R.string.reactandroid_catalyst_perf_monitor_stop) : mApplicationContext.getString(R.string.reactandroid_catalyst_perf_monitor), new DevOptionHandler() {
 
-            @Override
-            public void onOptionSelected() {
-                if (!mDevSettings.isFpsDebugEnabled()) {
-                    // Request overlay permission if needed when "Show Perf Monitor" option is selected
-                    Context context = mReactInstanceManagerHelper.getCurrentActivity();
-                    if (context == null) {
-                        FLog.e(ReactConstants.TAG, "Unable to get reference to react activity");
-                    } else {
-                        DebugOverlayController.requestPermission(context);
-                    }
-                }
-                mDevSettings.setFpsDebugEnabled(!mDevSettings.isFpsDebugEnabled());
+    options.put(
+        mDevSettings.isFpsDebugEnabled()
+            ? mApplicationContext.getString(R.string.reactandroid_catalyst_perf_monitor_stop)
+            : mApplicationContext.getString(R.string.reactandroid_catalyst_perf_monitor),
+        new DevOptionHandler() {
+          @Override
+          public void onOptionSelected() {
+            if (!mDevSettings.isFpsDebugEnabled()) {
+              // Request overlay permission if needed when "Show Perf Monitor" option is selected
+              Context context = mReactInstanceManagerHelper.getCurrentActivity();
+              if (context == null) {
+                FLog.e(ReactConstants.TAG, "Unable to get reference to react activity");
+              } else {
+                DebugOverlayController.requestPermission(context);
+              }
             }
+            mDevSettings.setFpsDebugEnabled(!mDevSettings.isFpsDebugEnabled());
+          }
         });
-
-      options.put(// NOTE: `isElementInspectorEnabled` is not guaranteed to be accurate.
-          mApplicationContext.getString(R.string.reactandroid_catalyst_inspector), new DevOptionHandler() {
-
-            @Override
-            public void onOptionSelected() {
-              mDevSettings.setElementInspectorEnabled(!mDevSettings.isElementInspectorEnabled());
-              mReactInstanceManagerHelper.toggleElementInspector();
-            }
-          });
-
-
-//        options.put(mApplicationContext.getString(R.string.reactandroid_catalyst_settings), new DevOptionHandler() {
-//
-//            @Override
-//            public void onOptionSelected() {
-//                Intent intent = new Intent(mApplicationContext, DevSettingsActivity.class);
-//                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-//                mApplicationContext.startActivity(intent);
-//            }
+//    options.put(
+//        mApplicationContext.getString(R.string.reactandroid_catalyst_settings),
+//        new DevOptionHandler() {
+//          @Override
+//          public void onOptionSelected() {
+//            Intent intent = new Intent(mApplicationContext, DevSettingsActivity.class);
+//            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+//            mApplicationContext.startActivity(intent);
+//          }
 //        });
 
-        if (mCustomDevOptions.size() > 0) {
-            options.putAll(mCustomDevOptions);
-        }
-        final DevOptionHandler[] optionHandlers = options.values().toArray(new DevOptionHandler[0]);
-        Activity context = mReactInstanceManagerHelper.getCurrentActivity();
-        if (context == null || context.isFinishing()) {
-            FLog.e(ReactConstants.TAG, "Unable to launch dev options menu because react activity " + "isn't available");
-            return;
-        }
-        mDevOptionsDialog = new AlertDialog.Builder(context).setItems(options.keySet().toArray(new String[0]), new DialogInterface.OnClickListener() {
-
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                optionHandlers[which].onOptionSelected();
-                mDevOptionsDialog = null;
-            }
-        }).setOnCancelListener(new DialogInterface.OnCancelListener() {
-
-            @Override
-            public void onCancel(DialogInterface dialog) {
-                mDevOptionsDialog = null;
-            }
-        }).create();
-        mDevOptionsDialog.show();
+    if (mCustomDevOptions.size() > 0) {
+      options.putAll(mCustomDevOptions);
     }
 
-    /** Starts of stops the sampling profiler */
-    private void toggleJSSamplingProfiler() {
-        JavaScriptExecutorFactory javaScriptExecutorFactory = mReactInstanceManagerHelper.getJavaScriptExecutorFactory();
-        if (!mIsSamplingProfilerEnabled) {
-            try {
-                javaScriptExecutorFactory.startSamplingProfiler();
-                Toast.makeText(mApplicationContext, "Starting Sampling Profiler", Toast.LENGTH_SHORT).show();
-            } catch (UnsupportedOperationException e) {
-                Toast.makeText(mApplicationContext, javaScriptExecutorFactory.toString() + " does not support Sampling Profiler", Toast.LENGTH_LONG).show();
-            } finally {
-                mIsSamplingProfilerEnabled = true;
-            }
-        } else {
-            try {
-                final String outputPath = File.createTempFile("sampling-profiler-trace", ".cpuprofile", mApplicationContext.getCacheDir()).getPath();
-                javaScriptExecutorFactory.stopSamplingProfiler(outputPath);
-                Toast.makeText(mApplicationContext, "Saved results from Profiler to " + outputPath, Toast.LENGTH_LONG).show();
-            } catch (IOException e) {
-                FLog.e(ReactConstants.TAG, "Could not create temporary file for saving results from Sampling Profiler");
-            } catch (UnsupportedOperationException e) {
-                Toast.makeText(mApplicationContext, javaScriptExecutorFactory.toString() + "does not support Sampling Profiler", Toast.LENGTH_LONG).show();
-            } finally {
-                mIsSamplingProfilerEnabled = false;
-            }
-        }
-    }
+    final DevOptionHandler[] optionHandlers = options.values().toArray(new DevOptionHandler[0]);
 
-    /**
+    Activity context = mReactInstanceManagerHelper.getCurrentActivity();
+    if (context == null || context.isFinishing()) {
+      FLog.e(
+          ReactConstants.TAG,
+          "Unable to launch dev options menu because react activity " + "isn't available");
+      return;
+    }
+    mDevOptionsDialog =
+        new AlertDialog.Builder(context)
+            .setItems(
+                options.keySet().toArray(new String[0]),
+                new DialogInterface.OnClickListener() {
+                  @Override
+                  public void onClick(DialogInterface dialog, int which) {
+                    optionHandlers[which].onOptionSelected();
+                    mDevOptionsDialog = null;
+                  }
+                })
+            .setOnCancelListener(
+                new DialogInterface.OnCancelListener() {
+                  @Override
+                  public void onCancel(DialogInterface dialog) {
+                    mDevOptionsDialog = null;
+                  }
+                })
+            .create();
+    mDevOptionsDialog.show();
+  }
+
+  /** Starts of stops the sampling profiler */
+  private void toggleJSSamplingProfiler() {
+    JavaScriptExecutorFactory javaScriptExecutorFactory =
+        mReactInstanceManagerHelper.getJavaScriptExecutorFactory();
+    if (!mIsSamplingProfilerEnabled) {
+      try {
+        javaScriptExecutorFactory.startSamplingProfiler();
+        Toast.makeText(mApplicationContext, "Starting Sampling Profiler", Toast.LENGTH_SHORT)
+            .show();
+      } catch (UnsupportedOperationException e) {
+        Toast.makeText(
+                mApplicationContext,
+                javaScriptExecutorFactory.toString() + " does not support Sampling Profiler",
+                Toast.LENGTH_LONG)
+            .show();
+      } finally {
+        mIsSamplingProfilerEnabled = true;
+      }
+    } else {
+      try {
+        final String outputPath =
+            File.createTempFile(
+                    "sampling-profiler-trace", ".cpuprofile", mApplicationContext.getCacheDir())
+                .getPath();
+        javaScriptExecutorFactory.stopSamplingProfiler(outputPath);
+        Toast.makeText(
+                mApplicationContext,
+                "Saved results from Profiler to " + outputPath,
+                Toast.LENGTH_LONG)
+            .show();
+      } catch (IOException e) {
+        FLog.e(
+            ReactConstants.TAG,
+            "Could not create temporary file for saving results from Sampling Profiler");
+      } catch (UnsupportedOperationException e) {
+        Toast.makeText(
+                mApplicationContext,
+                javaScriptExecutorFactory.toString() + "does not support Sampling Profiler",
+                Toast.LENGTH_LONG)
+            .show();
+      } finally {
+        mIsSamplingProfilerEnabled = false;
+      }
+    }
+  }
+
+  /**
    * {@link ReactInstanceDevCommandsHandler} is responsible for enabling/disabling dev support when
    * a React view is attached/detached or when application state changes (e.g. the application is
    * backgrounded).
    */
-    @Override
-    public void setDevSupportEnabled(boolean isDevSupportEnabled) {
-        mIsDevSupportEnabled = isDevSupportEnabled;
-        reloadSettings();
+  @Override
+  public void setDevSupportEnabled(boolean isDevSupportEnabled) {
+    mIsDevSupportEnabled = isDevSupportEnabled;
+    reloadSettings();
+  }
+
+  @Override
+  public boolean getDevSupportEnabled() {
+    return mIsDevSupportEnabled;
+  }
+
+  @Override
+  public DeveloperSettings getDevSettings() {
+    return mDevSettings;
+  }
+
+  @Override
+  public void onNewReactContextCreated(ReactContext reactContext) {
+    resetCurrentContext(reactContext);
+  }
+
+  @Override
+  public void onReactInstanceDestroyed(ReactContext reactContext) {
+    if (reactContext == mCurrentContext) {
+      // only call reset context when the destroyed context matches the one that is currently set
+      // for this manager
+      resetCurrentContext(null);
+    }
+  }
+
+  @Override
+  public String getSourceMapUrl() {
+    if (mJSAppBundleName == null) {
+      return "";
     }
 
-    @Override
-    public boolean getDevSupportEnabled() {
-        return mIsDevSupportEnabled;
+    return mDevServerHelper.getSourceMapUrl(Assertions.assertNotNull(mJSAppBundleName));
+  }
+
+  @Override
+  public String getSourceUrl() {
+    if (mJSAppBundleName == null) {
+      return "";
     }
 
-    @Override
-    public DeveloperSettings getDevSettings() {
-        return mDevSettings;
-    }
+    return mDevServerHelper.getSourceUrl(Assertions.assertNotNull(mJSAppBundleName));
+  }
 
-    @Override
-    public void onNewReactContextCreated(ReactContext reactContext) {
-        resetCurrentContext(reactContext);
-    }
+  @Override
+  public String getJSBundleURLForRemoteDebugging() {
+    return mDevServerHelper.getJSBundleURLForRemoteDebugging(
+        Assertions.assertNotNull(mJSAppBundleName));
+  }
 
-    @Override
-    public void onReactInstanceDestroyed(ReactContext reactContext) {
-        if (reactContext == mCurrentContext) {
-            // only call reset context when the destroyed context matches the one that is currently set
-            // for this manager
-            resetCurrentContext(null);
-        }
-    }
+  @Override
+  public String getDownloadedJSBundleFile() {
+    return mJSBundleTempFile.getAbsolutePath();
+  }
 
-    @Override
-    public String getSourceMapUrl() {
-        if (mJSAppBundleName == null) {
-            return "";
-        }
-        return mDevServerHelper.getSourceMapUrl(Assertions.assertNotNull(mJSAppBundleName));
-    }
-
-    @Override
-    public String getSourceUrl() {
-        if (mJSAppBundleName == null) {
-            return "";
-        }
-        return mDevServerHelper.getSourceUrl(Assertions.assertNotNull(mJSAppBundleName));
-    }
-
-    @Override
-    public String getJSBundleURLForRemoteDebugging() {
-        return mDevServerHelper.getJSBundleURLForRemoteDebugging(Assertions.assertNotNull(mJSAppBundleName));
-    }
-
-    @Override
-    public String getDownloadedJSBundleFile() {
-        return mJSBundleTempFile.getAbsolutePath();
-    }
-
-    /**
+  /**
    * @return {@code true} if {@link com.facebook.react.ReactInstanceManager} should use downloaded
    *     JS bundle file instead of using JS file from assets. This may happen when app has not been
    *     updated since the last time we fetched the bundle.
    */
-    @Override
-    public boolean hasUpToDateJSBundleInCache() {
-        return false;
-    }
+  @Override
+  public boolean hasUpToDateJSBundleInCache() {
+//    if (mIsDevSupportEnabled && mJSBundleTempFile.exists()) {
+//      try {
+//        String packageName = mApplicationContext.getPackageName();
+//        PackageInfo thisPackage =
+//            mApplicationContext.getPackageManager().getPackageInfo(packageName, 0);
+//        if (mJSBundleTempFile.lastModified() > thisPackage.lastUpdateTime) {
+//          // Base APK has not been updated since we downloaded JS, but if app is using exopackage
+//          // it may only be a single dex that has been updated. We check for exopackage dir update
+//          // time in that case.
+//          File exopackageDir =
+//              new File(String.format(Locale.US, EXOPACKAGE_LOCATION_FORMAT, packageName));
+//          if (exopackageDir.exists()) {
+//            return mJSBundleTempFile.lastModified() > exopackageDir.lastModified();
+//          }
+//          return true;
+//        }
+//      } catch (PackageManager.NameNotFoundException e) {
+//        // Ignore this error and just fallback to loading JS from assets
+//        FLog.e(ReactConstants.TAG, "DevSupport is unable to get current app info");
+//      }
+//    }
+    return false;
+  }
 
-    /**
+  /**
    * @return {@code true} if JS bundle {@param bundleAssetName} exists, in that case {@link
    *     com.facebook.react.ReactInstanceManager} should use that file from assets instead of
    *     downloading bundle from dev server
    */
-    public boolean hasBundleInAssets(String bundleAssetName) {
-        try {
-            String[] assets = mApplicationContext.getAssets().list("");
-            for (int i = 0; i < assets.length; i++) {
-                if (assets[i].equals(bundleAssetName)) {
-                    return true;
-                }
-            }
-        } catch (IOException e) {
-            // Ignore this error and just fallback to downloading JS from devserver
-            FLog.e(ReactConstants.TAG, "Error while loading assets list");
+  public boolean hasBundleInAssets(String bundleAssetName) {
+    try {
+      String[] assets = mApplicationContext.getAssets().list("");
+      for (int i = 0; i < assets.length; i++) {
+        if (assets[i].equals(bundleAssetName)) {
+          return true;
         }
-        return false;
+      }
+    } catch (IOException e) {
+      // Ignore this error and just fallback to downloading JS from devserver
+      FLog.e(ReactConstants.TAG, "Error while loading assets list");
+    }
+    return false;
+  }
+
+  private void resetCurrentContext(@Nullable ReactContext reactContext) {
+    if (mCurrentContext == reactContext) {
+      // new context is the same as the old one - do nothing
+      return;
     }
 
-    private void resetCurrentContext(@Nullable ReactContext reactContext) {
-        if (mCurrentContext == reactContext) {
-            // new context is the same as the old one - do nothing
-            return;
-        }
-        mCurrentContext = reactContext;
-        // Recreate debug overlay controller with new CatalystInstance object
-        if (mDebugOverlayController != null) {
-            mDebugOverlayController.setFpsDebugViewVisible(false);
-        }
-        if (reactContext != null) {
-            mDebugOverlayController = new DebugOverlayController(reactContext);
-        }
-        if (mCurrentContext != null) {
+    mCurrentContext = reactContext;
+
+    // Recreate debug overlay controller with new CatalystInstance object
+    if (mDebugOverlayController != null) {
+      mDebugOverlayController.setFpsDebugViewVisible(false);
+    }
+    if (reactContext != null) {
+      mDebugOverlayController = new DebugOverlayController(reactContext);
+    }
+
+    if (mCurrentContext != null) {
+      try {
+        URL sourceUrl = new URL(getSourceUrl());
+        String path = sourceUrl.getPath().substring(1); // strip initial slash in path
+        String host = sourceUrl.getHost();
+        int port = sourceUrl.getPort();
+        mCurrentContext
+            .getJSModule(HMRClient.class)
+            .setup("android", path, host, port, mDevSettings.isHotModuleReplacementEnabled());
+      } catch (MalformedURLException e) {
+        showNewJavaError(e.getMessage(), e);
+      }
+    }
+
+    reloadSettings();
+  }
+
+  @Override
+  public void reloadSettings() {
+    if (UiThreadUtil.isOnUiThread()) {
+      reload();
+    } else {
+      UiThreadUtil.runOnUiThread(
+          new Runnable() {
+            @Override
+            public void run() {
+              reload();
+            }
+          });
+    }
+  }
+
+  public void onInternalSettingsChanged() {
+    reloadSettings();
+  }
+
+  // NOTE(brentvatne): this is confusingly called the first time the app loads!
+  @Override
+  public void handleReloadJS() {
+
+    UiThreadUtil.assertOnUiThread();
+
+    ReactMarker.logMarker(
+        ReactMarkerConstants.RELOAD,
+        mDevSettings.getPackagerConnectionSettings().getDebugServerHost());
+
+    // dismiss redbox if exists
+    hideRedboxDialog();
+
+    if (mDevSettings.isRemoteJSDebugEnabled()) {
+      PrinterHolder.getPrinter()
+          .logMessage(ReactDebugOverlayTags.RN_CORE, "RNCore: load from Proxy");
+      mDevLoadingViewController.showForRemoteJSEnabled();
+      mDevLoadingViewVisible = true;
+      reloadJSInProxyMode();
+    } else {
+      PrinterHolder.getPrinter()
+          .logMessage(ReactDebugOverlayTags.RN_CORE, "RNCore: load from Server");
+      String bundleURL =
+          mDevServerHelper.getDevServerBundleURL(Assertions.assertNotNull(mJSAppBundleName));
+      reloadJSFromServer(bundleURL);
+    }
+  }
+
+  @Override
+  public void isPackagerRunning(PackagerStatusCallback callback) {
+    mDevServerHelper.isPackagerRunning(callback);
+  }
+
+  @Override
+  public @Nullable File downloadBundleResourceFromUrlSync(
+      final String resourceURL, final File outputFile) {
+    return mDevServerHelper.downloadBundleResourceFromUrlSync(resourceURL, outputFile);
+  }
+
+  @Override
+  public @Nullable String getLastErrorTitle() {
+    return mLastErrorTitle;
+  }
+
+  @Override
+  public @Nullable StackFrame[] getLastErrorStack() {
+    return mLastErrorStack;
+  }
+
+  @Override
+  public void onPackagerConnected() {
+    // No-op
+  }
+
+  @Override
+  public void onPackagerDisconnected() {
+    // No-op
+  }
+
+  @Override
+  public void onPackagerReloadCommand() {
+    // Disable debugger to resume the JsVM & avoid thread locks while reloading
+    mDevServerHelper.disableDebugger();
+    UiThreadUtil.runOnUiThread(
+        new Runnable() {
+          @Override
+          public void run() {
+            handleReloadJS();
+          }
+        });
+  }
+
+  @Override
+  public void onPackagerDevMenuCommand() {
+    UiThreadUtil.runOnUiThread(
+        new Runnable() {
+          @Override
+          public void run() {
+            showDevOptionsDialog();
+          }
+        });
+  }
+
+  @Override
+  public void onCaptureHeapCommand(final Responder responder) {
+    UiThreadUtil.runOnUiThread(
+        new Runnable() {
+          @Override
+          public void run() {
+            handleCaptureHeap(responder);
+          }
+        });
+  }
+
+  @Override
+  public @Nullable Map<String, RequestHandler> customCommandHandlers() {
+    return mCustomPackagerCommandHandlers;
+  }
+
+  private void handleCaptureHeap(final Responder responder) {
+    if (mCurrentContext == null) {
+      return;
+    }
+    JSCHeapCapture heapCapture = mCurrentContext.getNativeModule(JSCHeapCapture.class);
+    heapCapture.captureHeap(
+        mApplicationContext.getCacheDir().getPath(),
+        new JSCHeapCapture.CaptureCallback() {
+          @Override
+          public void onSuccess(File capture) {
+            responder.respond(capture.toString());
+          }
+
+          @Override
+          public void onFailure(JSCHeapCapture.CaptureException error) {
+            responder.error(error.toString());
+          }
+        });
+  }
+
+  private void updateLastErrorInfo(
+      @Nullable final String message,
+      final StackFrame[] stack,
+      final int errorCookie,
+      final ErrorType errorType) {
+    mLastErrorTitle = message;
+    mLastErrorStack = stack;
+    mLastErrorCookie = errorCookie;
+    mLastErrorType = errorType;
+  }
+
+  private void reloadJSInProxyMode() {
+    // When using js proxy, there is no need to fetch JS bundle as proxy executor will do that
+    // anyway
+    mDevServerHelper.launchJSDevtools();
+
+    JavaJSExecutor.Factory factory =
+        new JavaJSExecutor.Factory() {
+          @Override
+          public JavaJSExecutor create() throws Exception {
+            WebsocketJavaScriptExecutor executor = new WebsocketJavaScriptExecutor();
+            SimpleSettableFuture<Boolean> future = new SimpleSettableFuture<>();
+            executor.connect(
+                mDevServerHelper.getWebsocketProxyURL(), getExecutorConnectCallback(future));
+            // TODO(t9349129) Don't use timeout
             try {
-                URL sourceUrl = new URL(getSourceUrl());
-                // strip initial slash in path
-                String path = sourceUrl.getPath().substring(1);
-                String host = sourceUrl.getHost();
-                int port = sourceUrl.getPort();
-                mCurrentContext.getJSModule(HMRClient.class).setup("android", path, host, port, mDevSettings.isHotModuleReplacementEnabled());
-            } catch (MalformedURLException e) {
-                showNewJavaError(e.getMessage(), e);
+              future.get(90, TimeUnit.SECONDS);
+              return executor;
+            } catch (ExecutionException e) {
+              throw (Exception) e.getCause();
+            } catch (InterruptedException | TimeoutException e) {
+              throw new RuntimeException(e);
             }
-        }
-        reloadSettings();
-    }
-
-    @Override
-    public void reloadSettings() {
-        if (UiThreadUtil.isOnUiThread()) {
-            reload();
-        } else {
-            UiThreadUtil.runOnUiThread(new Runnable() {
-
-                @Override
-                public void run() {
-                    reload();
-                }
-            });
-        }
-    }
-
-    public void onInternalSettingsChanged() {
-        reloadSettings();
-    }
-
-    // NOTE(brentvatne): this is confusingly called the first time the app loads!
-    @Override
-    public void handleReloadJS() {
-        UiThreadUtil.assertOnUiThread();
-
-        ReactMarker.logMarker(ReactMarkerConstants.RELOAD, mDevSettings.getPackagerConnectionSettings().getDebugServerHost());
-        // dismiss redbox if exists
-        hideRedboxDialog();
-        if (mDevSettings.isRemoteJSDebugEnabled()) {
-            PrinterHolder.getPrinter().logMessage(ReactDebugOverlayTags.RN_CORE, "RNCore: load from Proxy");
-            mDevLoadingViewController.showForRemoteJSEnabled();
-            mDevLoadingViewVisible = true;
-            reloadJSInProxyMode();
-        } else {
-            PrinterHolder.getPrinter().logMessage(ReactDebugOverlayTags.RN_CORE, "RNCore: load from Server");
-            String bundleURL = mDevServerHelper.getDevServerBundleURL(Assertions.assertNotNull(mJSAppBundleName));
-            reloadJSFromServer(bundleURL);
-        }
-    }
-
-    @Override
-    public void isPackagerRunning(PackagerStatusCallback callback) {
-        mDevServerHelper.isPackagerRunning(callback);
-    }
-
-    @Override
-    @Nullable
-    public File downloadBundleResourceFromUrlSync(final String resourceURL, final File outputFile) {
-        return mDevServerHelper.downloadBundleResourceFromUrlSync(resourceURL, outputFile);
-    }
-
-    @Override
-    @Nullable
-    public String getLastErrorTitle() {
-        return mLastErrorTitle;
-    }
-
-    @Override
-    @Nullable
-    public StackFrame[] getLastErrorStack() {
-        return mLastErrorStack;
-    }
-
-    @Override
-    public void onPackagerConnected() {
-    // No-op
-    }
-
-    @Override
-    public void onPackagerDisconnected() {
-    // No-op
-    }
-
-    @Override
-    public void onPackagerReloadCommand() {
-        // Disable debugger to resume the JsVM & avoid thread locks while reloading
-        mDevServerHelper.disableDebugger();
-        UiThreadUtil.runOnUiThread(new Runnable() {
-
-            @Override
-            public void run() {
-                handleReloadJS();
-            }
-        });
-    }
-
-    @Override
-    public void onPackagerDevMenuCommand() {
-        UiThreadUtil.runOnUiThread(new Runnable() {
-
-            @Override
-            public void run() {
-                showDevOptionsDialog();
-            }
-        });
-    }
-
-    @Override
-    public void onCaptureHeapCommand(final Responder responder) {
-        UiThreadUtil.runOnUiThread(new Runnable() {
-
-            @Override
-            public void run() {
-                handleCaptureHeap(responder);
-            }
-        });
-    }
-
-    @Override
-    @Nullable
-    public Map<String, RequestHandler> customCommandHandlers() {
-        return mCustomPackagerCommandHandlers;
-    }
-
-    private void handleCaptureHeap(final Responder responder) {
-        if (mCurrentContext == null) {
-            return;
-        }
-        JSCHeapCapture heapCapture = mCurrentContext.getNativeModule(JSCHeapCapture.class);
-        heapCapture.captureHeap(mApplicationContext.getCacheDir().getPath(), new JSCHeapCapture.CaptureCallback() {
-
-            @Override
-            public void onSuccess(File capture) {
-                responder.respond(capture.toString());
-            }
-
-            @Override
-            public void onFailure(JSCHeapCapture.CaptureException error) {
-                responder.error(error.toString());
-            }
-        });
-    }
-
-    private void updateLastErrorInfo(@Nullable final String message, final StackFrame[] stack, final int errorCookie, final ErrorType errorType) {
-        mLastErrorTitle = message;
-        mLastErrorStack = stack;
-        mLastErrorCookie = errorCookie;
-        mLastErrorType = errorType;
-    }
-
-    private void reloadJSInProxyMode() {
-        // When using js proxy, there is no need to fetch JS bundle as proxy executor will do that
-        // anyway
-        mDevServerHelper.launchJSDevtools();
-        JavaJSExecutor.Factory factory = new JavaJSExecutor.Factory() {
-
-            @Override
-            public JavaJSExecutor create() throws Exception {
-                WebsocketJavaScriptExecutor executor = new WebsocketJavaScriptExecutor();
-                SimpleSettableFuture<Boolean> future = new SimpleSettableFuture<>();
-                executor.connect(mDevServerHelper.getWebsocketProxyURL(), getExecutorConnectCallback(future));
-                // TODO(t9349129) Don't use timeout
-                try {
-                    future.get(90, TimeUnit.SECONDS);
-                    return executor;
-                } catch (ExecutionException e) {
-                    throw (Exception) e.getCause();
-                } catch (InterruptedException | TimeoutException e) {
-                    throw new RuntimeException(e);
-                }
-            }
+          }
         };
-        mReactInstanceManagerHelper.onReloadWithJSDebugger(factory);
-    }
+    mReactInstanceManagerHelper.onReloadWithJSDebugger(factory);
+  }
 
-    private WebsocketJavaScriptExecutor.JSExecutorConnectCallback getExecutorConnectCallback(final SimpleSettableFuture<Boolean> future) {
-        return new WebsocketJavaScriptExecutor.JSExecutorConnectCallback() {
+  private WebsocketJavaScriptExecutor.JSExecutorConnectCallback getExecutorConnectCallback(
+      final SimpleSettableFuture<Boolean> future) {
+    return new WebsocketJavaScriptExecutor.JSExecutorConnectCallback() {
+      @Override
+      public void onSuccess() {
+        future.set(true);
+        mDevLoadingViewController.hide();
+        mDevLoadingViewVisible = false;
+      }
 
-            @Override
-            public void onSuccess() {
-                future.set(true);
-                mDevLoadingViewController.hide();
-                mDevLoadingViewVisible = false;
-            }
+      @Override
+      public void onFailure(final Throwable cause) {
+        mDevLoadingViewController.hide();
+        mDevLoadingViewVisible = false;
+        FLog.e(ReactConstants.TAG, "Failed to connect to debugger!", cause);
+        future.setException(
+            new IOException(mApplicationContext.getString(R.string.reactandroid_catalyst_debug_error), cause));
+      }
+    };
+  }
 
-            @Override
-            public void onFailure(final Throwable cause) {
-                mDevLoadingViewController.hide();
-                mDevLoadingViewVisible = false;
-                FLog.e(ReactConstants.TAG, "Failed to connect to debugger!", cause);
-                future.setException(new IOException(mApplicationContext.getString(R.string.reactandroid_catalyst_debug_error), cause));
-            }
-        };
-    }
+  public void reloadJSFromServer(final String bundleURL) {
+    ReactMarker.logMarker(ReactMarkerConstants.DOWNLOAD_START);
 
-    public void reloadJSFromServer(final String bundleURL) {
-        ReactMarker.logMarker(ReactMarkerConstants.DOWNLOAD_START);
-        mDevLoadingViewController.showForUrl(bundleURL);
-        mDevLoadingViewVisible = true;
-        final BundleDownloader.BundleInfo bundleInfo = new BundleDownloader.BundleInfo();
-        mDevServerHelper.downloadBundleFromURL(new DevBundleDownloadListener() {
+    mDevLoadingViewController.showForUrl(bundleURL);
+    mDevLoadingViewVisible = true;
 
-            @Override
-            public void onSuccess(@Nullable final NativeDeltaClient nativeDeltaClient) {
-                mDevLoadingViewController.hide();
-                mDevLoadingViewVisible = false;
-                synchronized (DevSupportManagerImpl.this) {
-                    mBundleStatus.isLastDownloadSucess = true;
-                    mBundleStatus.updateTimestamp = System.currentTimeMillis();
-                }
-                if (mBundleDownloadListener != null) {
-                    mBundleDownloadListener.onSuccess(nativeDeltaClient);
-                }
-                UiThreadUtil.runOnUiThread(new Runnable() {
+    final BundleDownloader.BundleInfo bundleInfo = new BundleDownloader.BundleInfo();
 
-                    @Override
-                    public void run() {
-                        ReactMarker.logMarker(ReactMarkerConstants.DOWNLOAD_END, bundleInfo.toJSONString());
-                        mReactInstanceManagerHelper.onJSBundleLoadedFromServer(nativeDeltaClient);
-                    }
-                });
-            }
-
-            @Override
-            public void onProgress(@Nullable final String status, @Nullable final Integer done, @Nullable final Integer total) {
-                mDevLoadingViewController.updateProgress(status, done, total);
-                if (mBundleDownloadListener != null) {
-                    mBundleDownloadListener.onProgress(status, done, total);
-                }
-            }
-
-            @Override
-            public void onFailure(final Exception cause) {
-                mDevLoadingViewController.hide();
-                mDevLoadingViewVisible = false;
-                synchronized (DevSupportManagerImpl.this) {
-                    mBundleStatus.isLastDownloadSucess = false;
-                }
-                if (mBundleDownloadListener != null) {
-                    mBundleDownloadListener.onFailure(cause);
-                }
-                FLog.e(ReactConstants.TAG, "Unable to download JS bundle", cause);
-                UiThreadUtil.runOnUiThread(new Runnable() {
-
-                    @Override
-                    public void run() {
-                        if (cause instanceof DebugServerException) {
-                            DebugServerException debugServerException = (DebugServerException) cause;
-                            showNewJavaError(debugServerException.getMessage(), cause);
-                        } else {
-                            showNewJavaError(mApplicationContext.getString(R.string.reactandroid_catalyst_reload_error), cause);
-                        }
-                    }
-                });
-            }
-        }, mJSBundleTempFile, bundleURL, bundleInfo);
-    }
-
-    @Override
-    public void startInspector() {
-        if (mIsDevSupportEnabled) {
-            mDevServerHelper.openInspectorConnection();
-        }
-    }
-
-    @Override
-    public void stopInspector() {
-        mDevServerHelper.closeInspectorConnection();
-    }
-
-    @Override
-    public void setHotModuleReplacementEnabled(final boolean isHotModuleReplacementEnabled) {
-        if (!mIsDevSupportEnabled) {
-            return;
-        }
-        UiThreadUtil.runOnUiThread(new Runnable() {
-
-            @Override
-            public void run() {
-                mDevSettings.setHotModuleReplacementEnabled(isHotModuleReplacementEnabled);
-                handleReloadJS();
-            }
-        });
-    }
-
-    @Override
-    public void setRemoteJSDebugEnabled(final boolean isRemoteJSDebugEnabled) {
-        if (!mIsDevSupportEnabled) {
-            return;
-        }
-        UiThreadUtil.runOnUiThread(new Runnable() {
-
-            @Override
-            public void run() {
-                mDevSettings.setRemoteJSDebugEnabled(isRemoteJSDebugEnabled);
-                handleReloadJS();
-            }
-        });
-    }
-
-    @Override
-    public void setReloadOnJSChangeEnabled(final boolean isReloadOnJSChangeEnabled) {
-        if (!mIsDevSupportEnabled) {
-            return;
-        }
-        UiThreadUtil.runOnUiThread(new Runnable() {
-
-            @Override
-            public void run() {
-                mDevSettings.setReloadOnJSChangeEnabled(isReloadOnJSChangeEnabled);
-                handleReloadJS();
-            }
-        });
-    }
-
-    @Override
-    public void setFpsDebugEnabled(final boolean isFpsDebugEnabled) {
-        if (!mIsDevSupportEnabled) {
-            return;
-        }
-        UiThreadUtil.runOnUiThread(new Runnable() {
-
-            @Override
-            public void run() {
-                mDevSettings.setFpsDebugEnabled(isFpsDebugEnabled);
-            }
-        });
-    }
-
-    @Override
-    public void toggleElementInspector() {
-        if (!mIsDevSupportEnabled) {
-            return;
-        }
-        UiThreadUtil.runOnUiThread(new Runnable() {
-
-            @Override
-            public void run() {
-                mDevSettings.setElementInspectorEnabled(!mDevSettings.isElementInspectorEnabled());
-                mReactInstanceManagerHelper.toggleElementInspector();
-            }
-        });
-    }
-
-    // NOTE(brentvatne): this is confusingly called the first time the app loads!
-    private void reload() {
-        UiThreadUtil.assertOnUiThread();
-        // reload settings, show/hide debug overlay if required & start/stop shake detector
-        if (mIsDevSupportEnabled) {
-            // update visibility of FPS debug overlay depending on the settings
-            if (mDebugOverlayController != null) {
-                mDebugOverlayController.setFpsDebugViewVisible(mDevSettings.isFpsDebugEnabled());
-            }
-            // start shake gesture detector
-            if (!mIsShakeDetectorStarted) {
-                mShakeDetector.start((SensorManager) mApplicationContext.getSystemService(Context.SENSOR_SERVICE));
-                mIsShakeDetectorStarted = true;
-            }
-            // register reload app broadcast receiver
-            if (!mIsReceiverRegistered) {
-                IntentFilter filter = new IntentFilter();
-                filter.addAction(getReloadAppAction(mApplicationContext));
-                mApplicationContext.registerReceiver(mReloadAppBroadcastReceiver, filter);
-                mIsReceiverRegistered = true;
-            }
-            // show the dev loading if it should be
-            if (mDevLoadingViewVisible) {
-                mDevLoadingViewController.showMessage("Reloading...");
-            }
-            mDevServerHelper.openPackagerConnection(this.getClass().getSimpleName(), this);
-            if (mDevSettings.isReloadOnJSChangeEnabled()) {
-                mDevServerHelper.startPollingOnChangeEndpoint(new DevServerHelper.OnServerContentChangeListener() {
-
-                    @Override
-                    public void onServerContentChanged() {
-                        handleReloadJS();
-                    }
-                });
-            } else {
-                mDevServerHelper.stopPollingOnChangeEndpoint();
-            }
-        } else {
-            // hide FPS debug overlay
-            if (mDebugOverlayController != null) {
-                mDebugOverlayController.setFpsDebugViewVisible(false);
-            }
-            // stop shake gesture detector
-            if (mIsShakeDetectorStarted) {
-                mShakeDetector.stop();
-                mIsShakeDetectorStarted = false;
-            }
-            // unregister app reload broadcast receiver
-            if (mIsReceiverRegistered) {
-                mApplicationContext.unregisterReceiver(mReloadAppBroadcastReceiver);
-                mIsReceiverRegistered = false;
-            }
-            // hide redbox dialog
-            hideRedboxDialog();
-            // hide dev options dialog
-            hideDevOptionsDialog();
-            // hide loading view
+    mDevServerHelper.downloadBundleFromURL(
+        new DevBundleDownloadListener() {
+          @Override
+          public void onSuccess(final @Nullable NativeDeltaClient nativeDeltaClient) {
             mDevLoadingViewController.hide();
-            mDevServerHelper.closePackagerConnection();
-            mDevServerHelper.stopPollingOnChangeEndpoint();
-        }
+            mDevLoadingViewVisible = false;
+            synchronized (DevSupportManagerImpl.this) {
+              mBundleStatus.isLastDownloadSucess = true;
+              mBundleStatus.updateTimestamp = System.currentTimeMillis();
+            }
+            if (mBundleDownloadListener != null) {
+              mBundleDownloadListener.onSuccess(nativeDeltaClient);
+            }
+            UiThreadUtil.runOnUiThread(
+                new Runnable() {
+                  @Override
+                  public void run() {
+                    ReactMarker.logMarker(
+                        ReactMarkerConstants.DOWNLOAD_END, bundleInfo.toJSONString());
+                    mReactInstanceManagerHelper.onJSBundleLoadedFromServer(nativeDeltaClient);
+                  }
+                });
+          }
+
+          @Override
+          public void onProgress(
+              @Nullable final String status,
+              @Nullable final Integer done,
+              @Nullable final Integer total) {
+            mDevLoadingViewController.updateProgress(status, done, total);
+            if (mBundleDownloadListener != null) {
+              mBundleDownloadListener.onProgress(status, done, total);
+            }
+          }
+
+          @Override
+          public void onFailure(final Exception cause) {
+            mDevLoadingViewController.hide();
+            mDevLoadingViewVisible = false;
+            synchronized (DevSupportManagerImpl.this) {
+              mBundleStatus.isLastDownloadSucess = false;
+            }
+            if (mBundleDownloadListener != null) {
+              mBundleDownloadListener.onFailure(cause);
+            }
+            FLog.e(ReactConstants.TAG, "Unable to download JS bundle", cause);
+            UiThreadUtil.runOnUiThread(
+                new Runnable() {
+                  @Override
+                  public void run() {
+                    if (cause instanceof DebugServerException) {
+                      DebugServerException debugServerException = (DebugServerException) cause;
+                      showNewJavaError(debugServerException.getMessage(), cause);
+                    } else {
+                      showNewJavaError(
+                          mApplicationContext.getString(R.string.reactandroid_catalyst_reload_error), cause);
+                    }
+                  }
+                });
+          }
+        },
+        mJSBundleTempFile,
+        bundleURL,
+        bundleInfo);
+  }
+
+  @Override
+  public void startInspector() {
+    if (mIsDevSupportEnabled) {
+      mDevServerHelper.openInspectorConnection();
+    }
+  }
+
+  @Override
+  public void stopInspector() {
+    mDevServerHelper.closeInspectorConnection();
+  }
+
+  @Override
+  public void setHotModuleReplacementEnabled(final boolean isHotModuleReplacementEnabled) {
+    if (!mIsDevSupportEnabled) {
+      return;
     }
 
-    /** Intent action for reloading the JS */
-    private static String getReloadAppAction(Context context) {
-        return context.getPackageName() + RELOAD_APP_ACTION_SUFFIX;
+    UiThreadUtil.runOnUiThread(
+        new Runnable() {
+          @Override
+          public void run() {
+            mDevSettings.setHotModuleReplacementEnabled(isHotModuleReplacementEnabled);
+            handleReloadJS();
+          }
+        });
+  }
+
+  @Override
+  public void setRemoteJSDebugEnabled(final boolean isRemoteJSDebugEnabled) {
+    if (!mIsDevSupportEnabled) {
+      return;
     }
+
+    UiThreadUtil.runOnUiThread(
+        new Runnable() {
+          @Override
+          public void run() {
+            mDevSettings.setRemoteJSDebugEnabled(isRemoteJSDebugEnabled);
+            handleReloadJS();
+          }
+        });
+  }
+
+  @Override
+  public void setReloadOnJSChangeEnabled(final boolean isReloadOnJSChangeEnabled) {
+    if (!mIsDevSupportEnabled) {
+      return;
+    }
+
+    UiThreadUtil.runOnUiThread(
+        new Runnable() {
+          @Override
+          public void run() {
+            mDevSettings.setReloadOnJSChangeEnabled(isReloadOnJSChangeEnabled);
+            handleReloadJS();
+          }
+        });
+  }
+
+  @Override
+  public void setFpsDebugEnabled(final boolean isFpsDebugEnabled) {
+    if (!mIsDevSupportEnabled) {
+      return;
+    }
+
+    UiThreadUtil.runOnUiThread(
+        new Runnable() {
+          @Override
+          public void run() {
+            mDevSettings.setFpsDebugEnabled(isFpsDebugEnabled);
+          }
+        });
+  }
+
+  @Override
+  public void toggleElementInspector() {
+    if (!mIsDevSupportEnabled) {
+      return;
+    }
+
+    UiThreadUtil.runOnUiThread(
+        new Runnable() {
+          @Override
+          public void run() {
+            mDevSettings.setElementInspectorEnabled(!mDevSettings.isElementInspectorEnabled());
+            mReactInstanceManagerHelper.toggleElementInspector();
+          }
+        });
+  }
+
+  // NOTE(brentvatne): this is confusingly called the first time the app loads!
+  private void reload() {
+    UiThreadUtil.assertOnUiThread();
+
+    // reload settings, show/hide debug overlay if required & start/stop shake detector
+    if (mIsDevSupportEnabled) {
+      // update visibility of FPS debug overlay depending on the settings
+      if (mDebugOverlayController != null) {
+        mDebugOverlayController.setFpsDebugViewVisible(mDevSettings.isFpsDebugEnabled());
+      }
+
+      // start shake gesture detector
+      if (!mIsShakeDetectorStarted) {
+        mShakeDetector.start(
+            (SensorManager) mApplicationContext.getSystemService(Context.SENSOR_SERVICE));
+        mIsShakeDetectorStarted = true;
+      }
+
+      // register reload app broadcast receiver
+      if (!mIsReceiverRegistered) {
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(getReloadAppAction(mApplicationContext));
+        mApplicationContext.registerReceiver(mReloadAppBroadcastReceiver, filter);
+        mIsReceiverRegistered = true;
+      }
+
+      // show the dev loading if it should be
+      if (mDevLoadingViewVisible) {
+        mDevLoadingViewController.showMessage("Reloading...");
+      }
+
+      mDevServerHelper.openPackagerConnection(this.getClass().getSimpleName(), this);
+      if (mDevSettings.isReloadOnJSChangeEnabled()) {
+        mDevServerHelper.startPollingOnChangeEndpoint(
+            new DevServerHelper.OnServerContentChangeListener() {
+              @Override
+              public void onServerContentChanged() {
+                handleReloadJS();
+              }
+            });
+      } else {
+        mDevServerHelper.stopPollingOnChangeEndpoint();
+      }
+    } else {
+      // hide FPS debug overlay
+      if (mDebugOverlayController != null) {
+        mDebugOverlayController.setFpsDebugViewVisible(false);
+      }
+
+      // stop shake gesture detector
+      if (mIsShakeDetectorStarted) {
+        mShakeDetector.stop();
+        mIsShakeDetectorStarted = false;
+      }
+
+      // unregister app reload broadcast receiver
+      if (mIsReceiverRegistered) {
+        mApplicationContext.unregisterReceiver(mReloadAppBroadcastReceiver);
+        mIsReceiverRegistered = false;
+      }
+
+      // hide redbox dialog
+      hideRedboxDialog();
+
+      // hide dev options dialog
+      hideDevOptionsDialog();
+
+      // hide loading view
+      mDevLoadingViewController.hide();
+      mDevServerHelper.closePackagerConnection();
+      mDevServerHelper.stopPollingOnChangeEndpoint();
+    }
+  }
+
+  /** Intent action for reloading the JS */
+  private static String getReloadAppAction(Context context) {
+    return context.getPackageName() + RELOAD_APP_ACTION_SUFFIX;
+  }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -89,1172 +89,1042 @@ import java.util.concurrent.TimeoutException;
  * {@code <activity android:name="com.facebook.react.devsupport.DevSettingsActivity"/>}
  * {@code <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>}
  */
-public class DevSupportManagerImpl
-    implements DevSupportManager, PackagerCommandListener, DevInternalSettings.Listener {
+public class DevSupportManagerImpl implements DevSupportManager, PackagerCommandListener, DevInternalSettings.Listener {
 
-  private static final int JAVA_ERROR_COOKIE = -1;
-  private static final int JSEXCEPTION_ERROR_COOKIE = -1;
-  private static final String JS_BUNDLE_FILE_NAME = "ReactNativeDevBundle.js";
-  private static final String RELOAD_APP_ACTION_SUFFIX = ".RELOAD_APP_ACTION";
-  private boolean mIsSamplingProfilerEnabled = false;
+    public static int JAVA_ERROR_COOKIE = -1;
 
-  private enum ErrorType {
-    JS,
-    NATIVE
-  }
+    public static int JSEXCEPTION_ERROR_COOKIE = -1;
 
-  private static final String EXOPACKAGE_LOCATION_FORMAT =
-      "/data/local/tmp/exopackage/%s//secondary-dex";
+    public static String JS_BUNDLE_FILE_NAME = "ReactNativeDevBundle.js";
 
-  public static final String EMOJI_HUNDRED_POINTS_SYMBOL = " \uD83D\uDCAF";
-  public static final String EMOJI_FACE_WITH_NO_GOOD_GESTURE = " \uD83D\uDE45";
+    public static String RELOAD_APP_ACTION_SUFFIX = ".RELOAD_APP_ACTION";
 
-  private final List<ExceptionLogger> mExceptionLoggers = new ArrayList<>();
+    public boolean mIsSamplingProfilerEnabled = false;
 
-  private final Context mApplicationContext;
-  private final ShakeDetector mShakeDetector;
-  private final BroadcastReceiver mReloadAppBroadcastReceiver;
-  private final DevServerHelper mDevServerHelper;
-  private final LinkedHashMap<String, DevOptionHandler> mCustomDevOptions = new LinkedHashMap<>();
-  private final ReactInstanceManagerDevHelper mReactInstanceManagerHelper;
-  private final @Nullable String mJSAppBundleName;
-  private final File mJSBundleTempFile;
-  private final DefaultNativeModuleCallExceptionHandler mDefaultNativeModuleCallExceptionHandler;
-  private final DevLoadingViewController mDevLoadingViewController;
+    private enum ErrorType {
 
-  private @Nullable RedBoxDialog mRedBoxDialog;
-  private @Nullable AlertDialog mDevOptionsDialog;
-  private @Nullable DebugOverlayController mDebugOverlayController;
-  private boolean mDevLoadingViewVisible = false;
-  private @Nullable ReactContext mCurrentContext;
-  private DevInternalSettings mDevSettings;
-  private boolean mIsReceiverRegistered = false;
-  private boolean mIsShakeDetectorStarted = false;
-  private boolean mIsDevSupportEnabled = false;
-  private @Nullable RedBoxHandler mRedBoxHandler;
-  private @Nullable String mLastErrorTitle;
-  private @Nullable StackFrame[] mLastErrorStack;
-  private int mLastErrorCookie = 0;
-  private @Nullable ErrorType mLastErrorType;
-  private @Nullable DevBundleDownloadListener mBundleDownloadListener;
-  private @Nullable List<ErrorCustomizer> mErrorCustomizers;
+        JS, NATIVE
+    }
 
-  private InspectorPackagerConnection.BundleStatus mBundleStatus;
+    public static String EXOPACKAGE_LOCATION_FORMAT = "/data/local/tmp/exopackage/%s//secondary-dex";
 
-  private @Nullable Map<String, RequestHandler> mCustomPackagerCommandHandlers;
+    public static String EMOJI_HUNDRED_POINTS_SYMBOL = " 💯";
 
-  public DevSupportManagerImpl(
-      Context applicationContext,
-      ReactInstanceManagerDevHelper reactInstanceManagerHelper,
-      @Nullable String packagerPathForJSBundleName,
-      boolean enableOnCreate,
-      int minNumShakes) {
+    public static String EMOJI_FACE_WITH_NO_GOOD_GESTURE = " 🙅";
 
-    this(
-        applicationContext,
-        reactInstanceManagerHelper,
-        packagerPathForJSBundleName,
-        enableOnCreate,
-        null,
-        null,
-        minNumShakes,
-        null);
-  }
+    public final List<ExceptionLogger> mExceptionLoggers = new ArrayList<>();
 
-  public DevSupportManagerImpl(
-      Context applicationContext,
-      ReactInstanceManagerDevHelper reactInstanceManagerHelper,
-      @Nullable String packagerPathForJSBundleName,
-      boolean enableOnCreate,
-      @Nullable RedBoxHandler redBoxHandler,
-      @Nullable DevBundleDownloadListener devBundleDownloadListener,
-      int minNumShakes,
-      @Nullable Map<String, RequestHandler> customPackagerCommandHandlers) {
-    mReactInstanceManagerHelper = reactInstanceManagerHelper;
-    mApplicationContext = applicationContext;
-    mJSAppBundleName = packagerPathForJSBundleName;
-    mDevSettings = new DevInternalSettings(applicationContext, this);
-    mBundleStatus = new InspectorPackagerConnection.BundleStatus();
-    mDevServerHelper =
-        new DevServerHelper(
-            mDevSettings,
-            mApplicationContext.getPackageName(),
-            new InspectorPackagerConnection.BundleStatusProvider() {
-              @Override
-              public InspectorPackagerConnection.BundleStatus getBundleStatus() {
+    public final Context mApplicationContext;
+
+    public final ShakeDetector mShakeDetector;
+
+    public final BroadcastReceiver mReloadAppBroadcastReceiver;
+
+    public final DevServerHelper mDevServerHelper;
+
+    public final LinkedHashMap<String, DevOptionHandler> mCustomDevOptions = new LinkedHashMap<>();
+
+    public final ReactInstanceManagerDevHelper mReactInstanceManagerHelper;
+
+    @Nullable
+    public final String mJSAppBundleName;
+
+    public final File mJSBundleTempFile;
+
+    public final DefaultNativeModuleCallExceptionHandler mDefaultNativeModuleCallExceptionHandler;
+
+    public final DevLoadingViewController mDevLoadingViewController;
+
+    @Nullable
+    public RedBoxDialog mRedBoxDialog;
+
+    @Nullable
+    public AlertDialog mDevOptionsDialog;
+
+    @Nullable
+    public DebugOverlayController mDebugOverlayController;
+
+    public boolean mDevLoadingViewVisible = false;
+
+    @Nullable
+    public ReactContext mCurrentContext;
+
+    public DevInternalSettings mDevSettings;
+
+    public boolean mIsReceiverRegistered = false;
+
+    public boolean mIsShakeDetectorStarted = false;
+
+    public boolean mIsDevSupportEnabled = false;
+
+    @Nullable
+    public RedBoxHandler mRedBoxHandler;
+
+    @Nullable
+    public String mLastErrorTitle;
+
+    @Nullable
+    public StackFrame[] mLastErrorStack;
+
+    public int mLastErrorCookie = 0;
+
+    @Nullable
+    public ErrorType mLastErrorType;
+
+    @Nullable
+    public DevBundleDownloadListener mBundleDownloadListener;
+
+    @Nullable
+    public List<ErrorCustomizer> mErrorCustomizers;
+
+    public InspectorPackagerConnection.BundleStatus mBundleStatus;
+
+    @Nullable
+    public Map<String, RequestHandler> mCustomPackagerCommandHandlers;
+
+    public DevSupportManagerImpl(Context applicationContext, ReactInstanceManagerDevHelper reactInstanceManagerHelper, @Nullable String packagerPathForJSBundleName, boolean enableOnCreate, int minNumShakes) {
+        this(applicationContext, reactInstanceManagerHelper, packagerPathForJSBundleName, enableOnCreate, null, null, minNumShakes, null);
+    }
+
+    public DevSupportManagerImpl(Context applicationContext, ReactInstanceManagerDevHelper reactInstanceManagerHelper, @Nullable String packagerPathForJSBundleName, boolean enableOnCreate, @Nullable RedBoxHandler redBoxHandler, @Nullable DevBundleDownloadListener devBundleDownloadListener, int minNumShakes, @Nullable Map<String, RequestHandler> customPackagerCommandHandlers) {
+        mReactInstanceManagerHelper = reactInstanceManagerHelper;
+        mApplicationContext = applicationContext;
+        mJSAppBundleName = packagerPathForJSBundleName;
+        mDevSettings = new DevInternalSettings(applicationContext, this);
+        mBundleStatus = new InspectorPackagerConnection.BundleStatus();
+        mDevServerHelper = new DevServerHelper(mDevSettings, mApplicationContext.getPackageName(), new InspectorPackagerConnection.BundleStatusProvider() {
+
+            @Override
+            public InspectorPackagerConnection.BundleStatus getBundleStatus() {
                 return mBundleStatus;
-              }
-            });
-    mBundleDownloadListener = devBundleDownloadListener;
-
-    // Prepare shake gesture detector (will be started/stopped from #reload)
-    mShakeDetector =
-        new ShakeDetector(
-            new ShakeDetector.ShakeListener() {
-              @Override
-              public void onShake() {
-                showDevOptionsDialog();
-              }
-            },
-            minNumShakes);
-
-    mCustomPackagerCommandHandlers = customPackagerCommandHandlers;
-
-    // Prepare reload APP broadcast receiver (will be registered/unregistered from #reload)
-    mReloadAppBroadcastReceiver =
-        new BroadcastReceiver() {
-          @Override
-          public void onReceive(Context context, Intent intent) {
-            String action = intent.getAction();
-            if (getReloadAppAction(context).equals(action)) {
-              if (intent.getBooleanExtra(DevServerHelper.RELOAD_APP_EXTRA_JS_PROXY, false)) {
-                mDevSettings.setRemoteJSDebugEnabled(true);
-                mDevServerHelper.launchJSDevtools();
-              } else {
-                mDevSettings.setRemoteJSDebugEnabled(false);
-              }
-              handleReloadJS();
             }
-          }
+        });
+        mBundleDownloadListener = devBundleDownloadListener;
+        // Prepare shake gesture detector (will be started/stopped from #reload)
+        mShakeDetector = new ShakeDetector(new ShakeDetector.ShakeListener() {
+
+            @Override
+            public void onShake() {
+                showDevOptionsDialog();
+            }
+        }, minNumShakes);
+        mCustomPackagerCommandHandlers = customPackagerCommandHandlers;
+        // Prepare reload APP broadcast receiver (will be registered/unregistered from #reload)
+        mReloadAppBroadcastReceiver = new BroadcastReceiver() {
+
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                String action = intent.getAction();
+                if (getReloadAppAction(context).equals(action)) {
+                    if (intent.getBooleanExtra(DevServerHelper.RELOAD_APP_EXTRA_JS_PROXY, false)) {
+                        mDevSettings.setRemoteJSDebugEnabled(true);
+                        mDevServerHelper.launchJSDevtools();
+                    } else {
+                        mDevSettings.setRemoteJSDebugEnabled(false);
+                    }
+                    handleReloadJS();
+                }
+            }
         };
-
-    // We store JS bundle loaded from dev server in a single destination in app's data dir.
-    // In case when someone schedule 2 subsequent reloads it may happen that JS thread will
-    // start reading first reload output while the second reload starts writing to the same
-    // file. As this should only be the case in dev mode we leave it as it is.
-    // TODO(6418010): Fix readers-writers problem in debug reload from HTTP server
-    mJSBundleTempFile = new File(applicationContext.getFilesDir(), JS_BUNDLE_FILE_NAME);
-
-    mDefaultNativeModuleCallExceptionHandler = new DefaultNativeModuleCallExceptionHandler();
-
-    setDevSupportEnabled(enableOnCreate);
-
-    mRedBoxHandler = redBoxHandler;
-    mDevLoadingViewController =
-        new DevLoadingViewController(applicationContext, reactInstanceManagerHelper);
-
-    mExceptionLoggers.add(new JSExceptionLogger());
-
-    if (mDevSettings.isStartSamplingProfilerOnInit()) {
-      // Only start the profiler. If its already running, there is an error
-      if (!mIsSamplingProfilerEnabled) {
-        toggleJSSamplingProfiler();
-      } else {
-        Toast.makeText(
-                mApplicationContext,
-                "JS Sampling Profiler was already running, so did not start the sampling profiler",
-                Toast.LENGTH_LONG)
-            .show();
-      }
+        // We store JS bundle loaded from dev server in a single destination in app's data dir.
+        // In case when someone schedule 2 subsequent reloads it may happen that JS thread will
+        // start reading first reload output while the second reload starts writing to the same
+        // file. As this should only be the case in dev mode we leave it as it is.
+        // TODO(6418010): Fix readers-writers problem in debug reload from HTTP server
+        mJSBundleTempFile = new File(applicationContext.getFilesDir(), JS_BUNDLE_FILE_NAME);
+        mDefaultNativeModuleCallExceptionHandler = new DefaultNativeModuleCallExceptionHandler();
+        setDevSupportEnabled(enableOnCreate);
+        mRedBoxHandler = redBoxHandler;
+        mDevLoadingViewController = new DevLoadingViewController(applicationContext, reactInstanceManagerHelper);
+        mExceptionLoggers.add(new JSExceptionLogger());
+        if (mDevSettings.isStartSamplingProfilerOnInit()) {
+            // Only start the profiler. If its already running, there is an error
+            if (!mIsSamplingProfilerEnabled) {
+                toggleJSSamplingProfiler();
+            } else {
+                Toast.makeText(mApplicationContext, "JS Sampling Profiler was already running, so did not start the sampling profiler", Toast.LENGTH_LONG).show();
+            }
+        }
     }
-  }
-
-  @Override
-  public void handleException(Exception e) {
-    if (mIsDevSupportEnabled) {
-
-      for (ExceptionLogger logger : mExceptionLoggers) {
-        logger.log(e);
-      }
-
-    } else {
-      mDefaultNativeModuleCallExceptionHandler.handleException(e);
-    }
-  }
-
-  private interface ExceptionLogger {
-    void log(Exception ex);
-  }
-
-  private class JSExceptionLogger implements ExceptionLogger {
 
     @Override
-    public void log(Exception e) {
-      StringBuilder message =
-          new StringBuilder(
-              e.getMessage() == null ? "Exception in native call from JS" : e.getMessage());
-      Throwable cause = e.getCause();
-      while (cause != null) {
-        message.append("\n\n").append(cause.getMessage());
-        cause = cause.getCause();
-      }
-
-      if (e instanceof JSException) {
-        FLog.e(ReactConstants.TAG, "Exception in native call from JS", e);
-        String stack = ((JSException) e).getStack();
-        message.append("\n\n").append(stack);
-
-        // TODO #11638796: convert the stack into something useful
-        showNewError(
-            message.toString(), new StackFrame[] {}, JSEXCEPTION_ERROR_COOKIE, ErrorType.JS);
-      } else {
-        showNewJavaError(message.toString(), e);
-      }
+    public void handleException(Exception e) {
+        try {
+            if (mIsDevSupportEnabled) {
+                for (ExceptionLogger logger : mExceptionLoggers) {
+                    logger.log(e);
+                }
+            } else {
+                mDefaultNativeModuleCallExceptionHandler.handleException(e);
+            }
+        } catch (RuntimeException expoException) {
+            try {
+                Class.forName("host.exp.exponent.ReactNativeStaticHelpers").getMethod("handleReactNativeError", String.class, Object.class, Integer.class, Boolean.class).invoke(null, expoException.getMessage(), null, -1, true);
+            } catch (Exception expoHandleErrorException) {
+                expoHandleErrorException.printStackTrace();
+            }
+        }
     }
-  }
 
-  @Override
-  public void showNewJavaError(@Nullable String message, Throwable e) {
-    FLog.e(ReactConstants.TAG, "Exception in native call", e);
-    showNewError(
-        message, StackTraceHelper.convertJavaStackTrace(e), JAVA_ERROR_COOKIE, ErrorType.NATIVE);
-  }
+    private interface ExceptionLogger {
 
-  /**
+        void log(Exception ex);
+    }
+
+    private class JSExceptionLogger implements ExceptionLogger {
+
+        @Override
+        public void log(Exception e) {
+            StringBuilder message = new StringBuilder(e.getMessage() == null ? "Exception in native call from JS" : e.getMessage());
+            Throwable cause = e.getCause();
+            while (cause != null) {
+                message.append("\n\n").append(cause.getMessage());
+                cause = cause.getCause();
+            }
+            if (e instanceof JSException) {
+                FLog.e(ReactConstants.TAG, "Exception in native call from JS", e);
+                String stack = ((JSException) e).getStack();
+                message.append("\n\n").append(stack);
+                // TODO #11638796: convert the stack into something useful
+                showNewError(message.toString(), new StackFrame[] {}, JSEXCEPTION_ERROR_COOKIE, ErrorType.JS);
+            } else {
+                showNewJavaError(message.toString(), e);
+            }
+        }
+    }
+
+    @Override
+    public void showNewJavaError(@Nullable String message, Throwable e) {
+        FLog.e(ReactConstants.TAG, "Exception in native call", e);
+        showNewError(message, StackTraceHelper.convertJavaStackTrace(e), JAVA_ERROR_COOKIE, ErrorType.NATIVE);
+    }
+
+    /**
    * Add option item to dev settings dialog displayed by this manager. In the case user select given
    * option from that dialog, the appropriate handler passed as {@param optionHandler} will be
    * called.
    */
-  @Override
-  public void addCustomDevOption(String optionName, DevOptionHandler optionHandler) {
-    mCustomDevOptions.put(optionName, optionHandler);
-  }
-
-  @Override
-  public void showNewJSError(String message, ReadableArray details, int errorCookie) {
-    showNewError(message, StackTraceHelper.convertJsStackTrace(details), errorCookie, ErrorType.JS);
-  }
-
-  @Override
-  public void registerErrorCustomizer(ErrorCustomizer errorCustomizer) {
-    if (mErrorCustomizers == null) {
-      mErrorCustomizers = new ArrayList<>();
+    @Override
+    public void addCustomDevOption(String optionName, DevOptionHandler optionHandler) {
+        mCustomDevOptions.put(optionName, optionHandler);
     }
-    mErrorCustomizers.add(errorCustomizer);
-  }
 
-  private Pair<String, StackFrame[]> processErrorCustomizers(Pair<String, StackFrame[]> errorInfo) {
-    if (mErrorCustomizers == null) {
-      return errorInfo;
-    } else {
-      for (ErrorCustomizer errorCustomizer : mErrorCustomizers) {
-        Pair<String, StackFrame[]> result = errorCustomizer.customizeErrorInfo(errorInfo);
-        if (result != null) {
-          errorInfo = result;
+    @Override
+    public void showNewJSError(String message, ReadableArray details, int errorCookie) {
+        showNewError(message, StackTraceHelper.convertJsStackTrace(details), errorCookie, ErrorType.JS);
+    }
+
+    @Override
+    public void registerErrorCustomizer(ErrorCustomizer errorCustomizer) {
+        if (mErrorCustomizers == null) {
+            mErrorCustomizers = new ArrayList<>();
         }
+        mErrorCustomizers.add(errorCustomizer);
+    }
+
+    private Pair<String, StackFrame[]> processErrorCustomizers(Pair<String, StackFrame[]> errorInfo) {
+        if (mErrorCustomizers == null) {
+            return errorInfo;
+        } else {
+            for (ErrorCustomizer errorCustomizer : mErrorCustomizers) {
+                Pair<String, StackFrame[]> result = errorCustomizer.customizeErrorInfo(errorInfo);
+                if (result != null) {
+                    errorInfo = result;
+                }
+            }
+            return errorInfo;
+        }
+    }
+
+    @Override
+    public void updateJSError(final String message, final ReadableArray details, final int errorCookie) {
+        UiThreadUtil.runOnUiThread(new Runnable() {
+
+            @Override
+            public void run() {
+                // belongs to the most recent showNewJSError
+                if (mRedBoxDialog == null || !mRedBoxDialog.isShowing() || errorCookie != mLastErrorCookie) {
+                    return;
+                }
+                StackFrame[] stack = StackTraceHelper.convertJsStackTrace(details);
+                Pair<String, StackFrame[]> errorInfo = processErrorCustomizers(Pair.create(message, stack));
+                mRedBoxDialog.setExceptionDetails(errorInfo.first, errorInfo.second);
+                updateLastErrorInfo(message, stack, errorCookie, ErrorType.JS);
+                // JS errors are reported here after source mapping.
+                if (mRedBoxHandler != null) {
+                    mRedBoxHandler.handleRedbox(message, stack, RedBoxHandler.ErrorType.JS);
+                    mRedBoxDialog.resetReporting();
+                }
+                mRedBoxDialog.show();
+            }
+        });
+    }
+
+    @Override
+    public void hideRedboxDialog() {
+        // dismiss redbox if exists
+        if (mRedBoxDialog != null) {
+            mRedBoxDialog.dismiss();
+            mRedBoxDialog = null;
+        }
+    }
+
+    private void hideDevOptionsDialog() {
+        if (mDevOptionsDialog != null) {
+            mDevOptionsDialog.dismiss();
+            mDevOptionsDialog = null;
+        }
+    }
+
+    private void showNewError(@Nullable final String message, final StackFrame[] stack, final int errorCookie, final ErrorType errorType) {
+        UiThreadUtil.runOnUiThread(new Runnable() {
+
+            @Override
+            public void run() {
+                if (mRedBoxDialog == null) {
+                    Activity context = mReactInstanceManagerHelper.getCurrentActivity();
+                    if (context == null || context.isFinishing()) {
+                        FLog.e(ReactConstants.TAG, "Unable to launch redbox because react activity " + "is not available, here is the error that redbox would've displayed: " + message);
+                        return;
+                    }
+                    mRedBoxDialog = new RedBoxDialog(context, DevSupportManagerImpl.this, mRedBoxHandler);
+                }
+                if (mRedBoxDialog.isShowing()) {
+                    // show the first and most actionable one.
+                    return;
+                }
+                Pair<String, StackFrame[]> errorInfo = processErrorCustomizers(Pair.create(message, stack));
+                mRedBoxDialog.setExceptionDetails(errorInfo.first, errorInfo.second);
+                updateLastErrorInfo(message, stack, errorCookie, errorType);
+                // inside {@link #updateJSError} after source mapping.
+                if (mRedBoxHandler != null && errorType == ErrorType.NATIVE) {
+                    mRedBoxHandler.handleRedbox(message, stack, RedBoxHandler.ErrorType.NATIVE);
+                }
+                mRedBoxDialog.resetReporting();
+                mRedBoxDialog.show();
+            }
+        });
+    }
+
+    @Override
+    public void reloadExpoApp() {
+      try {
+        int activityId = mDevServerHelper.mSettings.exponentActivityId;
+        Class.forName("host.exp.exponent.ReactNativeStaticHelpers").getMethod("reloadFromManifest", int.class).invoke(null, activityId);
+      } catch (Exception expoHandleErrorException) {
+        expoHandleErrorException.printStackTrace();
       }
-      return errorInfo;
     }
-  }
 
-  @Override
-  public void updateJSError(
-      final String message, final ReadableArray details, final int errorCookie) {
-    UiThreadUtil.runOnUiThread(
-        new Runnable() {
-          @Override
-          public void run() {
-            // Since we only show the first JS error in a succession of JS errors, make sure we only
-            // update the error message for that error message. This assumes that updateJSError
-            // belongs to the most recent showNewJSError
-            if (mRedBoxDialog == null
-                || !mRedBoxDialog.isShowing()
-                || errorCookie != mLastErrorCookie) {
-              return;
-            }
-            StackFrame[] stack = StackTraceHelper.convertJsStackTrace(details);
-            Pair<String, StackFrame[]> errorInfo =
-                processErrorCustomizers(Pair.create(message, stack));
-            mRedBoxDialog.setExceptionDetails(errorInfo.first, errorInfo.second);
-            updateLastErrorInfo(message, stack, errorCookie, ErrorType.JS);
-            // JS errors are reported here after source mapping.
-            if (mRedBoxHandler != null) {
-              mRedBoxHandler.handleRedbox(message, stack, RedBoxHandler.ErrorType.JS);
-              mRedBoxDialog.resetReporting();
-            }
-            mRedBoxDialog.show();
-          }
-        });
-  }
 
-  @Override
-  public void hideRedboxDialog() {
-    // dismiss redbox if exists
-    if (mRedBoxDialog != null) {
-      mRedBoxDialog.dismiss();
-      mRedBoxDialog = null;
-    }
-  }
+    @Override
+    public void showDevOptionsDialog() {
+        if (mDevOptionsDialog != null || !mIsDevSupportEnabled || ActivityManager.isUserAMonkey()) {
+            return;
+        }
+        LinkedHashMap<String, DevOptionHandler> options = new LinkedHashMap<>();
+        /* register standard options */
+        options.put(mApplicationContext.getString(R.string.reactandroid_catalyst_reload), new DevOptionHandler() {
 
-  private void hideDevOptionsDialog() {
-    if (mDevOptionsDialog != null) {
-      mDevOptionsDialog.dismiss();
-      mDevOptionsDialog = null;
-    }
-  }
-
-  private void showNewError(
-      @Nullable final String message,
-      final StackFrame[] stack,
-      final int errorCookie,
-      final ErrorType errorType) {
-    UiThreadUtil.runOnUiThread(
-        new Runnable() {
-          @Override
-          public void run() {
-            if (mRedBoxDialog == null) {
-              Activity context = mReactInstanceManagerHelper.getCurrentActivity();
-              if (context == null || context.isFinishing()) {
-                FLog.e(
-                    ReactConstants.TAG,
-                    "Unable to launch redbox because react activity "
-                        + "is not available, here is the error that redbox would've displayed: "
-                        + message);
-                return;
-              }
-              mRedBoxDialog = new RedBoxDialog(context, DevSupportManagerImpl.this, mRedBoxHandler);
-            }
-            if (mRedBoxDialog.isShowing()) {
-              // Sometimes errors cause multiple errors to be thrown in JS in quick succession. Only
-              // show the first and most actionable one.
-              return;
-            }
-            Pair<String, StackFrame[]> errorInfo =
-                processErrorCustomizers(Pair.create(message, stack));
-            mRedBoxDialog.setExceptionDetails(errorInfo.first, errorInfo.second);
-            updateLastErrorInfo(message, stack, errorCookie, errorType);
-            // Only report native errors here. JS errors are reported
-            // inside {@link #updateJSError} after source mapping.
-            if (mRedBoxHandler != null && errorType == ErrorType.NATIVE) {
-              mRedBoxHandler.handleRedbox(message, stack, RedBoxHandler.ErrorType.NATIVE);
-            }
-            mRedBoxDialog.resetReporting();
-            mRedBoxDialog.show();
-          }
-        });
-  }
-
-  @Override
-  public void showDevOptionsDialog() {
-    if (mDevOptionsDialog != null || !mIsDevSupportEnabled || ActivityManager.isUserAMonkey()) {
-      return;
-    }
-    LinkedHashMap<String, DevOptionHandler> options = new LinkedHashMap<>();
-    /* register standard options */
-    options.put(
-        mApplicationContext.getString(R.string.reactandroid_catalyst_reload),
-        new DevOptionHandler() {
-          @Override
-          public void onOptionSelected() {
-            if (!mDevSettings.isJSDevModeEnabled()
-                && mDevSettings.isHotModuleReplacementEnabled()) {
-              Toast.makeText(
-                      mApplicationContext,
-                      mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading_auto_disable),
-                      Toast.LENGTH_LONG)
-                  .show();
-              mDevSettings.setHotModuleReplacementEnabled(false);
-            }
-            handleReloadJS();
-          }
-        });
-    options.put(
-        mDevSettings.isNuclideJSDebugEnabled()
-            ? mDevSettings.isRemoteJSDebugEnabled()
-                ? mApplicationContext.getString(R.string.reactandroid_catalyst_debug_chrome_stop)
-                : mApplicationContext.getString(R.string.reactandroid_catalyst_debug_chrome)
-            : mDevSettings.isRemoteJSDebugEnabled()
-                ? mApplicationContext.getString(R.string.reactandroid_catalyst_debug_stop)
-                : mApplicationContext.getString(R.string.reactandroid_catalyst_debug),
-        new DevOptionHandler() {
-          @Override
-          public void onOptionSelected() {
-            mDevSettings.setRemoteJSDebugEnabled(!mDevSettings.isRemoteJSDebugEnabled());
-            handleReloadJS();
-          }
-        });
-    if (mDevSettings.isNuclideJSDebugEnabled()) {
-      options.put(
-          mApplicationContext.getString(R.string.reactandroid_catalyst_debug_nuclide),
-          new DevOptionHandler() {
             @Override
             public void onOptionSelected() {
-              mDevServerHelper.attachDebugger(mApplicationContext, "ReactNative");
+                if (!mDevSettings.isJSDevModeEnabled() && mDevSettings.isHotModuleReplacementEnabled()) {
+                    Toast.makeText(mApplicationContext, mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading_auto_disable), Toast.LENGTH_LONG).show();
+                    mDevSettings.setHotModuleReplacementEnabled(false);
+                }
+
+                // NOTE(brentvatne): rather than reload just JS we need to reload the entire project from manifest
+                // handleReloadJS();
+                reloadExpoApp();
+            }
+        });
+
+//        if (mDevSettings.isNuclideJSDebugEnabled()) {
+//            options.put(mApplicationContext.getString(R.string.reactandroid_catalyst_debug_nuclide), new DevOptionHandler() {
+//
+//                @Override
+//                public void onOptionSelected() {
+//                    mDevServerHelper.attachDebugger(mApplicationContext, "ReactNative");
+//                }
+//            });
+//        }
+
+        // NOTE(brentvatne): This option does not make sense for Expo
+//        options.put(mApplicationContext.getString(R.string.reactandroid_catalyst_change_bundle_location), new DevOptionHandler() {
+//
+//            @Override
+//            public void onOptionSelected() {
+//                Activity context = mReactInstanceManagerHelper.getCurrentActivity();
+//                if (context == null || context.isFinishing()) {
+//                    FLog.e(ReactConstants.TAG, "Unable to launch change bundle location because react activity is not available");
+//                    return;
+//                }
+//                final EditText input = new EditText(context);
+//                input.setHint("localhost:8081");
+//                AlertDialog bundleLocationDialog = new AlertDialog.Builder(context).setTitle(mApplicationContext.getString(R.string.reactandroid_catalyst_change_bundle_location)).setView(input).setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+//
+//                    @Override
+//                    public void onClick(DialogInterface dialog, int which) {
+//                        String host = input.getText().toString();
+//                        mDevSettings.getPackagerConnectionSettings().setDebugServerHost(host);
+//                        handleReloadJS();
+//                    }
+//                }).create();
+//                bundleLocationDialog.show();
+//            }
+//        });
+
+        // "Live reload" which refreshes on every edit was removed in favor of "Fast Refresh".
+        // While native code for "Live reload" is still there, please don't add the option back.
+        // See D15958697 for more context.
+        options.put(mDevSettings.isHotModuleReplacementEnabled() ? mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading_stop) : mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading), new DevOptionHandler() {
+
+            @Override
+            public void onOptionSelected() {
+                boolean nextEnabled = !mDevSettings.isHotModuleReplacementEnabled();
+                mDevSettings.setHotModuleReplacementEnabled(nextEnabled);
+                if (mCurrentContext != null) {
+                    if (nextEnabled) {
+                        mCurrentContext.getJSModule(HMRClient.class).enable();
+                    } else {
+                        mCurrentContext.getJSModule(HMRClient.class).disable();
+                    }
+                }
+//                if (nextEnabled && !mDevSettings.isJSDevModeEnabled()) {
+//                    Toast.makeText(mApplicationContext, mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading_auto_enable), Toast.LENGTH_LONG).show();
+//                    mDevSettings.setJSDevModeEnabled(true);
+//                    handleReloadJS();
+//                }
+            }
+        });
+
+
+      options.put(mDevSettings.isNuclideJSDebugEnabled() ? mDevSettings.isRemoteJSDebugEnabled() ? mApplicationContext.getString(R.string.reactandroid_catalyst_debug_chrome_stop) : mApplicationContext.getString(R.string.reactandroid_catalyst_debug_chrome) : mDevSettings.isRemoteJSDebugEnabled() ? mApplicationContext.getString(R.string.reactandroid_catalyst_debug_stop) : mApplicationContext.getString(R.string.reactandroid_catalyst_debug), new DevOptionHandler() {
+
+        @Override
+        public void onOptionSelected() {
+          mDevSettings.setRemoteJSDebugEnabled(!mDevSettings.isRemoteJSDebugEnabled());
+          handleReloadJS();
+        }
+      });
+
+
+
+//        options.put(mIsSamplingProfilerEnabled ? mApplicationContext.getString(R.string.reactandroid_catalyst_sample_profiler_disable) : mApplicationContext.getString(R.string.reactandroid_catalyst_sample_profiler_enable), new DevOptionHandler() {
+//
+//            @Override
+//            public void onOptionSelected() {
+//                toggleJSSamplingProfiler();
+//            }
+//        });
+        options.put(mDevSettings.isFpsDebugEnabled() ? mApplicationContext.getString(R.string.reactandroid_catalyst_perf_monitor_stop) : mApplicationContext.getString(R.string.reactandroid_catalyst_perf_monitor), new DevOptionHandler() {
+
+            @Override
+            public void onOptionSelected() {
+                if (!mDevSettings.isFpsDebugEnabled()) {
+                    // Request overlay permission if needed when "Show Perf Monitor" option is selected
+                    Context context = mReactInstanceManagerHelper.getCurrentActivity();
+                    if (context == null) {
+                        FLog.e(ReactConstants.TAG, "Unable to get reference to react activity");
+                    } else {
+                        DebugOverlayController.requestPermission(context);
+                    }
+                }
+                mDevSettings.setFpsDebugEnabled(!mDevSettings.isFpsDebugEnabled());
+            }
+        });
+
+      options.put(// NOTE: `isElementInspectorEnabled` is not guaranteed to be accurate.
+          mApplicationContext.getString(R.string.reactandroid_catalyst_inspector), new DevOptionHandler() {
+
+            @Override
+            public void onOptionSelected() {
+              mDevSettings.setElementInspectorEnabled(!mDevSettings.isElementInspectorEnabled());
+              mReactInstanceManagerHelper.toggleElementInspector();
             }
           });
-    }
-    options.put(
-        mApplicationContext.getString(R.string.reactandroid_catalyst_change_bundle_location),
-        new DevOptionHandler() {
-          @Override
-          public void onOptionSelected() {
-            Activity context = mReactInstanceManagerHelper.getCurrentActivity();
-            if (context == null || context.isFinishing()) {
-              FLog.e(
-                  ReactConstants.TAG,
-                  "Unable to launch change bundle location because react activity is not available");
-              return;
+
+
+//        options.put(mApplicationContext.getString(R.string.reactandroid_catalyst_settings), new DevOptionHandler() {
+//
+//            @Override
+//            public void onOptionSelected() {
+//                Intent intent = new Intent(mApplicationContext, DevSettingsActivity.class);
+//                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+//                mApplicationContext.startActivity(intent);
+//            }
+//        });
+
+        if (mCustomDevOptions.size() > 0) {
+            options.putAll(mCustomDevOptions);
+        }
+        final DevOptionHandler[] optionHandlers = options.values().toArray(new DevOptionHandler[0]);
+        Activity context = mReactInstanceManagerHelper.getCurrentActivity();
+        if (context == null || context.isFinishing()) {
+            FLog.e(ReactConstants.TAG, "Unable to launch dev options menu because react activity " + "isn't available");
+            return;
+        }
+        mDevOptionsDialog = new AlertDialog.Builder(context).setItems(options.keySet().toArray(new String[0]), new DialogInterface.OnClickListener() {
+
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                optionHandlers[which].onOptionSelected();
+                mDevOptionsDialog = null;
             }
+        }).setOnCancelListener(new DialogInterface.OnCancelListener() {
 
-            final EditText input = new EditText(context);
-            input.setHint("localhost:8081");
-
-            AlertDialog bundleLocationDialog =
-                new AlertDialog.Builder(context)
-                    .setTitle(
-                        mApplicationContext.getString(R.string.reactandroid_catalyst_change_bundle_location))
-                    .setView(input)
-                    .setPositiveButton(
-                        android.R.string.ok,
-                        new DialogInterface.OnClickListener() {
-                          @Override
-                          public void onClick(DialogInterface dialog, int which) {
-                            String host = input.getText().toString();
-                            mDevSettings.getPackagerConnectionSettings().setDebugServerHost(host);
-                            handleReloadJS();
-                          }
-                        })
-                    .create();
-            bundleLocationDialog.show();
-          }
-        });
-    options.put(
-        // NOTE: `isElementInspectorEnabled` is not guaranteed to be accurate.
-        mApplicationContext.getString(R.string.reactandroid_catalyst_inspector),
-        new DevOptionHandler() {
-          @Override
-          public void onOptionSelected() {
-            mDevSettings.setElementInspectorEnabled(!mDevSettings.isElementInspectorEnabled());
-            mReactInstanceManagerHelper.toggleElementInspector();
-          }
-        });
-    // "Live reload" which refreshes on every edit was removed in favor of "Fast Refresh".
-    // While native code for "Live reload" is still there, please don't add the option back.
-    // See D15958697 for more context.
-    options.put(
-        mDevSettings.isHotModuleReplacementEnabled()
-            ? mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading_stop)
-            : mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading),
-        new DevOptionHandler() {
-          @Override
-          public void onOptionSelected() {
-            boolean nextEnabled = !mDevSettings.isHotModuleReplacementEnabled();
-            mDevSettings.setHotModuleReplacementEnabled(nextEnabled);
-            if (mCurrentContext != null) {
-              if (nextEnabled) {
-                mCurrentContext.getJSModule(HMRClient.class).enable();
-              } else {
-                mCurrentContext.getJSModule(HMRClient.class).disable();
-              }
+            @Override
+            public void onCancel(DialogInterface dialog) {
+                mDevOptionsDialog = null;
             }
-            if (nextEnabled && !mDevSettings.isJSDevModeEnabled()) {
-              Toast.makeText(
-                      mApplicationContext,
-                      mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading_auto_enable),
-                      Toast.LENGTH_LONG)
-                  .show();
-              mDevSettings.setJSDevModeEnabled(true);
-              handleReloadJS();
-            }
-          }
-        });
-
-    options.put(
-        mIsSamplingProfilerEnabled
-            ? mApplicationContext.getString(R.string.reactandroid_catalyst_sample_profiler_disable)
-            : mApplicationContext.getString(R.string.reactandroid_catalyst_sample_profiler_enable),
-        new DevOptionHandler() {
-          @Override
-          public void onOptionSelected() {
-            toggleJSSamplingProfiler();
-          }
-        });
-
-    options.put(
-        mDevSettings.isFpsDebugEnabled()
-            ? mApplicationContext.getString(R.string.reactandroid_catalyst_perf_monitor_stop)
-            : mApplicationContext.getString(R.string.reactandroid_catalyst_perf_monitor),
-        new DevOptionHandler() {
-          @Override
-          public void onOptionSelected() {
-            if (!mDevSettings.isFpsDebugEnabled()) {
-              // Request overlay permission if needed when "Show Perf Monitor" option is selected
-              Context context = mReactInstanceManagerHelper.getCurrentActivity();
-              if (context == null) {
-                FLog.e(ReactConstants.TAG, "Unable to get reference to react activity");
-              } else {
-                DebugOverlayController.requestPermission(context);
-              }
-            }
-            mDevSettings.setFpsDebugEnabled(!mDevSettings.isFpsDebugEnabled());
-          }
-        });
-    options.put(
-        mApplicationContext.getString(R.string.reactandroid_catalyst_settings),
-        new DevOptionHandler() {
-          @Override
-          public void onOptionSelected() {
-            Intent intent = new Intent(mApplicationContext, DevSettingsActivity.class);
-            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            mApplicationContext.startActivity(intent);
-          }
-        });
-
-    if (mCustomDevOptions.size() > 0) {
-      options.putAll(mCustomDevOptions);
+        }).create();
+        mDevOptionsDialog.show();
     }
 
-    final DevOptionHandler[] optionHandlers = options.values().toArray(new DevOptionHandler[0]);
-
-    Activity context = mReactInstanceManagerHelper.getCurrentActivity();
-    if (context == null || context.isFinishing()) {
-      FLog.e(
-          ReactConstants.TAG,
-          "Unable to launch dev options menu because react activity " + "isn't available");
-      return;
+    /** Starts of stops the sampling profiler */
+    private void toggleJSSamplingProfiler() {
+        JavaScriptExecutorFactory javaScriptExecutorFactory = mReactInstanceManagerHelper.getJavaScriptExecutorFactory();
+        if (!mIsSamplingProfilerEnabled) {
+            try {
+                javaScriptExecutorFactory.startSamplingProfiler();
+                Toast.makeText(mApplicationContext, "Starting Sampling Profiler", Toast.LENGTH_SHORT).show();
+            } catch (UnsupportedOperationException e) {
+                Toast.makeText(mApplicationContext, javaScriptExecutorFactory.toString() + " does not support Sampling Profiler", Toast.LENGTH_LONG).show();
+            } finally {
+                mIsSamplingProfilerEnabled = true;
+            }
+        } else {
+            try {
+                final String outputPath = File.createTempFile("sampling-profiler-trace", ".cpuprofile", mApplicationContext.getCacheDir()).getPath();
+                javaScriptExecutorFactory.stopSamplingProfiler(outputPath);
+                Toast.makeText(mApplicationContext, "Saved results from Profiler to " + outputPath, Toast.LENGTH_LONG).show();
+            } catch (IOException e) {
+                FLog.e(ReactConstants.TAG, "Could not create temporary file for saving results from Sampling Profiler");
+            } catch (UnsupportedOperationException e) {
+                Toast.makeText(mApplicationContext, javaScriptExecutorFactory.toString() + "does not support Sampling Profiler", Toast.LENGTH_LONG).show();
+            } finally {
+                mIsSamplingProfilerEnabled = false;
+            }
+        }
     }
-    mDevOptionsDialog =
-        new AlertDialog.Builder(context)
-            .setItems(
-                options.keySet().toArray(new String[0]),
-                new DialogInterface.OnClickListener() {
-                  @Override
-                  public void onClick(DialogInterface dialog, int which) {
-                    optionHandlers[which].onOptionSelected();
-                    mDevOptionsDialog = null;
-                  }
-                })
-            .setOnCancelListener(
-                new DialogInterface.OnCancelListener() {
-                  @Override
-                  public void onCancel(DialogInterface dialog) {
-                    mDevOptionsDialog = null;
-                  }
-                })
-            .create();
-    mDevOptionsDialog.show();
-  }
 
-  /** Starts of stops the sampling profiler */
-  private void toggleJSSamplingProfiler() {
-    JavaScriptExecutorFactory javaScriptExecutorFactory =
-        mReactInstanceManagerHelper.getJavaScriptExecutorFactory();
-    if (!mIsSamplingProfilerEnabled) {
-      try {
-        javaScriptExecutorFactory.startSamplingProfiler();
-        Toast.makeText(mApplicationContext, "Starting Sampling Profiler", Toast.LENGTH_SHORT)
-            .show();
-      } catch (UnsupportedOperationException e) {
-        Toast.makeText(
-                mApplicationContext,
-                javaScriptExecutorFactory.toString() + " does not support Sampling Profiler",
-                Toast.LENGTH_LONG)
-            .show();
-      } finally {
-        mIsSamplingProfilerEnabled = true;
-      }
-    } else {
-      try {
-        final String outputPath =
-            File.createTempFile(
-                    "sampling-profiler-trace", ".cpuprofile", mApplicationContext.getCacheDir())
-                .getPath();
-        javaScriptExecutorFactory.stopSamplingProfiler(outputPath);
-        Toast.makeText(
-                mApplicationContext,
-                "Saved results from Profiler to " + outputPath,
-                Toast.LENGTH_LONG)
-            .show();
-      } catch (IOException e) {
-        FLog.e(
-            ReactConstants.TAG,
-            "Could not create temporary file for saving results from Sampling Profiler");
-      } catch (UnsupportedOperationException e) {
-        Toast.makeText(
-                mApplicationContext,
-                javaScriptExecutorFactory.toString() + "does not support Sampling Profiler",
-                Toast.LENGTH_LONG)
-            .show();
-      } finally {
-        mIsSamplingProfilerEnabled = false;
-      }
-    }
-  }
-
-  /**
+    /**
    * {@link ReactInstanceDevCommandsHandler} is responsible for enabling/disabling dev support when
    * a React view is attached/detached or when application state changes (e.g. the application is
    * backgrounded).
    */
-  @Override
-  public void setDevSupportEnabled(boolean isDevSupportEnabled) {
-    mIsDevSupportEnabled = isDevSupportEnabled;
-    reloadSettings();
-  }
-
-  @Override
-  public boolean getDevSupportEnabled() {
-    return mIsDevSupportEnabled;
-  }
-
-  @Override
-  public DeveloperSettings getDevSettings() {
-    return mDevSettings;
-  }
-
-  @Override
-  public void onNewReactContextCreated(ReactContext reactContext) {
-    resetCurrentContext(reactContext);
-  }
-
-  @Override
-  public void onReactInstanceDestroyed(ReactContext reactContext) {
-    if (reactContext == mCurrentContext) {
-      // only call reset context when the destroyed context matches the one that is currently set
-      // for this manager
-      resetCurrentContext(null);
-    }
-  }
-
-  @Override
-  public String getSourceMapUrl() {
-    if (mJSAppBundleName == null) {
-      return "";
+    @Override
+    public void setDevSupportEnabled(boolean isDevSupportEnabled) {
+        mIsDevSupportEnabled = isDevSupportEnabled;
+        reloadSettings();
     }
 
-    return mDevServerHelper.getSourceMapUrl(Assertions.assertNotNull(mJSAppBundleName));
-  }
-
-  @Override
-  public String getSourceUrl() {
-    if (mJSAppBundleName == null) {
-      return "";
+    @Override
+    public boolean getDevSupportEnabled() {
+        return mIsDevSupportEnabled;
     }
 
-    return mDevServerHelper.getSourceUrl(Assertions.assertNotNull(mJSAppBundleName));
-  }
+    @Override
+    public DeveloperSettings getDevSettings() {
+        return mDevSettings;
+    }
 
-  @Override
-  public String getJSBundleURLForRemoteDebugging() {
-    return mDevServerHelper.getJSBundleURLForRemoteDebugging(
-        Assertions.assertNotNull(mJSAppBundleName));
-  }
+    @Override
+    public void onNewReactContextCreated(ReactContext reactContext) {
+        resetCurrentContext(reactContext);
+    }
 
-  @Override
-  public String getDownloadedJSBundleFile() {
-    return mJSBundleTempFile.getAbsolutePath();
-  }
+    @Override
+    public void onReactInstanceDestroyed(ReactContext reactContext) {
+        if (reactContext == mCurrentContext) {
+            // only call reset context when the destroyed context matches the one that is currently set
+            // for this manager
+            resetCurrentContext(null);
+        }
+    }
 
-  /**
+    @Override
+    public String getSourceMapUrl() {
+        if (mJSAppBundleName == null) {
+            return "";
+        }
+        return mDevServerHelper.getSourceMapUrl(Assertions.assertNotNull(mJSAppBundleName));
+    }
+
+    @Override
+    public String getSourceUrl() {
+        if (mJSAppBundleName == null) {
+            return "";
+        }
+        return mDevServerHelper.getSourceUrl(Assertions.assertNotNull(mJSAppBundleName));
+    }
+
+    @Override
+    public String getJSBundleURLForRemoteDebugging() {
+        return mDevServerHelper.getJSBundleURLForRemoteDebugging(Assertions.assertNotNull(mJSAppBundleName));
+    }
+
+    @Override
+    public String getDownloadedJSBundleFile() {
+        return mJSBundleTempFile.getAbsolutePath();
+    }
+
+    /**
    * @return {@code true} if {@link com.facebook.react.ReactInstanceManager} should use downloaded
    *     JS bundle file instead of using JS file from assets. This may happen when app has not been
    *     updated since the last time we fetched the bundle.
    */
-  @Override
-  public boolean hasUpToDateJSBundleInCache() {
-    if (mIsDevSupportEnabled && mJSBundleTempFile.exists()) {
-      try {
-        String packageName = mApplicationContext.getPackageName();
-        PackageInfo thisPackage =
-            mApplicationContext.getPackageManager().getPackageInfo(packageName, 0);
-        if (mJSBundleTempFile.lastModified() > thisPackage.lastUpdateTime) {
-          // Base APK has not been updated since we downloaded JS, but if app is using exopackage
-          // it may only be a single dex that has been updated. We check for exopackage dir update
-          // time in that case.
-          File exopackageDir =
-              new File(String.format(Locale.US, EXOPACKAGE_LOCATION_FORMAT, packageName));
-          if (exopackageDir.exists()) {
-            return mJSBundleTempFile.lastModified() > exopackageDir.lastModified();
-          }
-          return true;
-        }
-      } catch (PackageManager.NameNotFoundException e) {
-        // Ignore this error and just fallback to loading JS from assets
-        FLog.e(ReactConstants.TAG, "DevSupport is unable to get current app info");
-      }
+    @Override
+    public boolean hasUpToDateJSBundleInCache() {
+        return false;
     }
-    return false;
-  }
 
-  /**
+    /**
    * @return {@code true} if JS bundle {@param bundleAssetName} exists, in that case {@link
    *     com.facebook.react.ReactInstanceManager} should use that file from assets instead of
    *     downloading bundle from dev server
    */
-  public boolean hasBundleInAssets(String bundleAssetName) {
-    try {
-      String[] assets = mApplicationContext.getAssets().list("");
-      for (int i = 0; i < assets.length; i++) {
-        if (assets[i].equals(bundleAssetName)) {
-          return true;
+    public boolean hasBundleInAssets(String bundleAssetName) {
+        try {
+            String[] assets = mApplicationContext.getAssets().list("");
+            for (int i = 0; i < assets.length; i++) {
+                if (assets[i].equals(bundleAssetName)) {
+                    return true;
+                }
+            }
+        } catch (IOException e) {
+            // Ignore this error and just fallback to downloading JS from devserver
+            FLog.e(ReactConstants.TAG, "Error while loading assets list");
         }
-      }
-    } catch (IOException e) {
-      // Ignore this error and just fallback to downloading JS from devserver
-      FLog.e(ReactConstants.TAG, "Error while loading assets list");
-    }
-    return false;
-  }
-
-  private void resetCurrentContext(@Nullable ReactContext reactContext) {
-    if (mCurrentContext == reactContext) {
-      // new context is the same as the old one - do nothing
-      return;
+        return false;
     }
 
-    mCurrentContext = reactContext;
-
-    // Recreate debug overlay controller with new CatalystInstance object
-    if (mDebugOverlayController != null) {
-      mDebugOverlayController.setFpsDebugViewVisible(false);
+    private void resetCurrentContext(@Nullable ReactContext reactContext) {
+        if (mCurrentContext == reactContext) {
+            // new context is the same as the old one - do nothing
+            return;
+        }
+        mCurrentContext = reactContext;
+        // Recreate debug overlay controller with new CatalystInstance object
+        if (mDebugOverlayController != null) {
+            mDebugOverlayController.setFpsDebugViewVisible(false);
+        }
+        if (reactContext != null) {
+            mDebugOverlayController = new DebugOverlayController(reactContext);
+        }
+        if (mCurrentContext != null) {
+            try {
+                URL sourceUrl = new URL(getSourceUrl());
+                // strip initial slash in path
+                String path = sourceUrl.getPath().substring(1);
+                String host = sourceUrl.getHost();
+                int port = sourceUrl.getPort();
+                mCurrentContext.getJSModule(HMRClient.class).setup("android", path, host, port, mDevSettings.isHotModuleReplacementEnabled());
+            } catch (MalformedURLException e) {
+                showNewJavaError(e.getMessage(), e);
+            }
+        }
+        reloadSettings();
     }
-    if (reactContext != null) {
-      mDebugOverlayController = new DebugOverlayController(reactContext);
+
+    @Override
+    public void reloadSettings() {
+        if (UiThreadUtil.isOnUiThread()) {
+            reload();
+        } else {
+            UiThreadUtil.runOnUiThread(new Runnable() {
+
+                @Override
+                public void run() {
+                    reload();
+                }
+            });
+        }
     }
 
-    if (mCurrentContext != null) {
-      try {
-        URL sourceUrl = new URL(getSourceUrl());
-        String path = sourceUrl.getPath().substring(1); // strip initial slash in path
-        String host = sourceUrl.getHost();
-        int port = sourceUrl.getPort();
-        mCurrentContext
-            .getJSModule(HMRClient.class)
-            .setup("android", path, host, port, mDevSettings.isHotModuleReplacementEnabled());
-      } catch (MalformedURLException e) {
-        showNewJavaError(e.getMessage(), e);
-      }
+    public void onInternalSettingsChanged() {
+        reloadSettings();
     }
 
-    reloadSettings();
-  }
+    // NOTE(brentvatne): this is confusingly called the first time the app loads!
+    @Override
+    public void handleReloadJS() {
+        UiThreadUtil.assertOnUiThread();
 
-  @Override
-  public void reloadSettings() {
-    if (UiThreadUtil.isOnUiThread()) {
-      reload();
-    } else {
-      UiThreadUtil.runOnUiThread(
-          new Runnable() {
+        ReactMarker.logMarker(ReactMarkerConstants.RELOAD, mDevSettings.getPackagerConnectionSettings().getDebugServerHost());
+        // dismiss redbox if exists
+        hideRedboxDialog();
+        if (mDevSettings.isRemoteJSDebugEnabled()) {
+            PrinterHolder.getPrinter().logMessage(ReactDebugOverlayTags.RN_CORE, "RNCore: load from Proxy");
+            mDevLoadingViewController.showForRemoteJSEnabled();
+            mDevLoadingViewVisible = true;
+            reloadJSInProxyMode();
+        } else {
+            PrinterHolder.getPrinter().logMessage(ReactDebugOverlayTags.RN_CORE, "RNCore: load from Server");
+            String bundleURL = mDevServerHelper.getDevServerBundleURL(Assertions.assertNotNull(mJSAppBundleName));
+            reloadJSFromServer(bundleURL);
+        }
+    }
+
+    @Override
+    public void isPackagerRunning(PackagerStatusCallback callback) {
+        mDevServerHelper.isPackagerRunning(callback);
+    }
+
+    @Override
+    @Nullable
+    public File downloadBundleResourceFromUrlSync(final String resourceURL, final File outputFile) {
+        return mDevServerHelper.downloadBundleResourceFromUrlSync(resourceURL, outputFile);
+    }
+
+    @Override
+    @Nullable
+    public String getLastErrorTitle() {
+        return mLastErrorTitle;
+    }
+
+    @Override
+    @Nullable
+    public StackFrame[] getLastErrorStack() {
+        return mLastErrorStack;
+    }
+
+    @Override
+    public void onPackagerConnected() {
+    // No-op
+    }
+
+    @Override
+    public void onPackagerDisconnected() {
+    // No-op
+    }
+
+    @Override
+    public void onPackagerReloadCommand() {
+        // Disable debugger to resume the JsVM & avoid thread locks while reloading
+        mDevServerHelper.disableDebugger();
+        UiThreadUtil.runOnUiThread(new Runnable() {
+
             @Override
             public void run() {
-              reload();
-            }
-          });
-    }
-  }
-
-  public void onInternalSettingsChanged() {
-    reloadSettings();
-  }
-
-  @Override
-  public void handleReloadJS() {
-
-    UiThreadUtil.assertOnUiThread();
-
-    ReactMarker.logMarker(
-        ReactMarkerConstants.RELOAD,
-        mDevSettings.getPackagerConnectionSettings().getDebugServerHost());
-
-    // dismiss redbox if exists
-    hideRedboxDialog();
-
-    if (mDevSettings.isRemoteJSDebugEnabled()) {
-      PrinterHolder.getPrinter()
-          .logMessage(ReactDebugOverlayTags.RN_CORE, "RNCore: load from Proxy");
-      mDevLoadingViewController.showForRemoteJSEnabled();
-      mDevLoadingViewVisible = true;
-      reloadJSInProxyMode();
-    } else {
-      PrinterHolder.getPrinter()
-          .logMessage(ReactDebugOverlayTags.RN_CORE, "RNCore: load from Server");
-      String bundleURL =
-          mDevServerHelper.getDevServerBundleURL(Assertions.assertNotNull(mJSAppBundleName));
-      reloadJSFromServer(bundleURL);
-    }
-  }
-
-  @Override
-  public void isPackagerRunning(PackagerStatusCallback callback) {
-    mDevServerHelper.isPackagerRunning(callback);
-  }
-
-  @Override
-  public @Nullable File downloadBundleResourceFromUrlSync(
-      final String resourceURL, final File outputFile) {
-    return mDevServerHelper.downloadBundleResourceFromUrlSync(resourceURL, outputFile);
-  }
-
-  @Override
-  public @Nullable String getLastErrorTitle() {
-    return mLastErrorTitle;
-  }
-
-  @Override
-  public @Nullable StackFrame[] getLastErrorStack() {
-    return mLastErrorStack;
-  }
-
-  @Override
-  public void onPackagerConnected() {
-    // No-op
-  }
-
-  @Override
-  public void onPackagerDisconnected() {
-    // No-op
-  }
-
-  @Override
-  public void onPackagerReloadCommand() {
-    // Disable debugger to resume the JsVM & avoid thread locks while reloading
-    mDevServerHelper.disableDebugger();
-    UiThreadUtil.runOnUiThread(
-        new Runnable() {
-          @Override
-          public void run() {
-            handleReloadJS();
-          }
-        });
-  }
-
-  @Override
-  public void onPackagerDevMenuCommand() {
-    UiThreadUtil.runOnUiThread(
-        new Runnable() {
-          @Override
-          public void run() {
-            showDevOptionsDialog();
-          }
-        });
-  }
-
-  @Override
-  public void onCaptureHeapCommand(final Responder responder) {
-    UiThreadUtil.runOnUiThread(
-        new Runnable() {
-          @Override
-          public void run() {
-            handleCaptureHeap(responder);
-          }
-        });
-  }
-
-  @Override
-  public @Nullable Map<String, RequestHandler> customCommandHandlers() {
-    return mCustomPackagerCommandHandlers;
-  }
-
-  private void handleCaptureHeap(final Responder responder) {
-    if (mCurrentContext == null) {
-      return;
-    }
-    JSCHeapCapture heapCapture = mCurrentContext.getNativeModule(JSCHeapCapture.class);
-    heapCapture.captureHeap(
-        mApplicationContext.getCacheDir().getPath(),
-        new JSCHeapCapture.CaptureCallback() {
-          @Override
-          public void onSuccess(File capture) {
-            responder.respond(capture.toString());
-          }
-
-          @Override
-          public void onFailure(JSCHeapCapture.CaptureException error) {
-            responder.error(error.toString());
-          }
-        });
-  }
-
-  private void updateLastErrorInfo(
-      @Nullable final String message,
-      final StackFrame[] stack,
-      final int errorCookie,
-      final ErrorType errorType) {
-    mLastErrorTitle = message;
-    mLastErrorStack = stack;
-    mLastErrorCookie = errorCookie;
-    mLastErrorType = errorType;
-  }
-
-  private void reloadJSInProxyMode() {
-    // When using js proxy, there is no need to fetch JS bundle as proxy executor will do that
-    // anyway
-    mDevServerHelper.launchJSDevtools();
-
-    JavaJSExecutor.Factory factory =
-        new JavaJSExecutor.Factory() {
-          @Override
-          public JavaJSExecutor create() throws Exception {
-            WebsocketJavaScriptExecutor executor = new WebsocketJavaScriptExecutor();
-            SimpleSettableFuture<Boolean> future = new SimpleSettableFuture<>();
-            executor.connect(
-                mDevServerHelper.getWebsocketProxyURL(), getExecutorConnectCallback(future));
-            // TODO(t9349129) Don't use timeout
-            try {
-              future.get(90, TimeUnit.SECONDS);
-              return executor;
-            } catch (ExecutionException e) {
-              throw (Exception) e.getCause();
-            } catch (InterruptedException | TimeoutException e) {
-              throw new RuntimeException(e);
-            }
-          }
-        };
-    mReactInstanceManagerHelper.onReloadWithJSDebugger(factory);
-  }
-
-  private WebsocketJavaScriptExecutor.JSExecutorConnectCallback getExecutorConnectCallback(
-      final SimpleSettableFuture<Boolean> future) {
-    return new WebsocketJavaScriptExecutor.JSExecutorConnectCallback() {
-      @Override
-      public void onSuccess() {
-        future.set(true);
-        mDevLoadingViewController.hide();
-        mDevLoadingViewVisible = false;
-      }
-
-      @Override
-      public void onFailure(final Throwable cause) {
-        mDevLoadingViewController.hide();
-        mDevLoadingViewVisible = false;
-        FLog.e(ReactConstants.TAG, "Failed to connect to debugger!", cause);
-        future.setException(
-            new IOException(mApplicationContext.getString(R.string.reactandroid_catalyst_debug_error), cause));
-      }
-    };
-  }
-
-  public void reloadJSFromServer(final String bundleURL) {
-    ReactMarker.logMarker(ReactMarkerConstants.DOWNLOAD_START);
-
-    mDevLoadingViewController.showForUrl(bundleURL);
-    mDevLoadingViewVisible = true;
-
-    final BundleDownloader.BundleInfo bundleInfo = new BundleDownloader.BundleInfo();
-
-    mDevServerHelper.downloadBundleFromURL(
-        new DevBundleDownloadListener() {
-          @Override
-          public void onSuccess(final @Nullable NativeDeltaClient nativeDeltaClient) {
-            mDevLoadingViewController.hide();
-            mDevLoadingViewVisible = false;
-            synchronized (DevSupportManagerImpl.this) {
-              mBundleStatus.isLastDownloadSucess = true;
-              mBundleStatus.updateTimestamp = System.currentTimeMillis();
-            }
-            if (mBundleDownloadListener != null) {
-              mBundleDownloadListener.onSuccess(nativeDeltaClient);
-            }
-            UiThreadUtil.runOnUiThread(
-                new Runnable() {
-                  @Override
-                  public void run() {
-                    ReactMarker.logMarker(
-                        ReactMarkerConstants.DOWNLOAD_END, bundleInfo.toJSONString());
-                    mReactInstanceManagerHelper.onJSBundleLoadedFromServer(nativeDeltaClient);
-                  }
-                });
-          }
-
-          @Override
-          public void onProgress(
-              @Nullable final String status,
-              @Nullable final Integer done,
-              @Nullable final Integer total) {
-            mDevLoadingViewController.updateProgress(status, done, total);
-            if (mBundleDownloadListener != null) {
-              mBundleDownloadListener.onProgress(status, done, total);
-            }
-          }
-
-          @Override
-          public void onFailure(final Exception cause) {
-            mDevLoadingViewController.hide();
-            mDevLoadingViewVisible = false;
-            synchronized (DevSupportManagerImpl.this) {
-              mBundleStatus.isLastDownloadSucess = false;
-            }
-            if (mBundleDownloadListener != null) {
-              mBundleDownloadListener.onFailure(cause);
-            }
-            FLog.e(ReactConstants.TAG, "Unable to download JS bundle", cause);
-            UiThreadUtil.runOnUiThread(
-                new Runnable() {
-                  @Override
-                  public void run() {
-                    if (cause instanceof DebugServerException) {
-                      DebugServerException debugServerException = (DebugServerException) cause;
-                      showNewJavaError(debugServerException.getMessage(), cause);
-                    } else {
-                      showNewJavaError(
-                          mApplicationContext.getString(R.string.reactandroid_catalyst_reload_error), cause);
-                    }
-                  }
-                });
-          }
-        },
-        mJSBundleTempFile,
-        bundleURL,
-        bundleInfo);
-  }
-
-  @Override
-  public void startInspector() {
-    if (mIsDevSupportEnabled) {
-      mDevServerHelper.openInspectorConnection();
-    }
-  }
-
-  @Override
-  public void stopInspector() {
-    mDevServerHelper.closeInspectorConnection();
-  }
-
-  @Override
-  public void setHotModuleReplacementEnabled(final boolean isHotModuleReplacementEnabled) {
-    if (!mIsDevSupportEnabled) {
-      return;
-    }
-
-    UiThreadUtil.runOnUiThread(
-        new Runnable() {
-          @Override
-          public void run() {
-            mDevSettings.setHotModuleReplacementEnabled(isHotModuleReplacementEnabled);
-            handleReloadJS();
-          }
-        });
-  }
-
-  @Override
-  public void setRemoteJSDebugEnabled(final boolean isRemoteJSDebugEnabled) {
-    if (!mIsDevSupportEnabled) {
-      return;
-    }
-
-    UiThreadUtil.runOnUiThread(
-        new Runnable() {
-          @Override
-          public void run() {
-            mDevSettings.setRemoteJSDebugEnabled(isRemoteJSDebugEnabled);
-            handleReloadJS();
-          }
-        });
-  }
-
-  @Override
-  public void setReloadOnJSChangeEnabled(final boolean isReloadOnJSChangeEnabled) {
-    if (!mIsDevSupportEnabled) {
-      return;
-    }
-
-    UiThreadUtil.runOnUiThread(
-        new Runnable() {
-          @Override
-          public void run() {
-            mDevSettings.setReloadOnJSChangeEnabled(isReloadOnJSChangeEnabled);
-            handleReloadJS();
-          }
-        });
-  }
-
-  @Override
-  public void setFpsDebugEnabled(final boolean isFpsDebugEnabled) {
-    if (!mIsDevSupportEnabled) {
-      return;
-    }
-
-    UiThreadUtil.runOnUiThread(
-        new Runnable() {
-          @Override
-          public void run() {
-            mDevSettings.setFpsDebugEnabled(isFpsDebugEnabled);
-          }
-        });
-  }
-
-  @Override
-  public void toggleElementInspector() {
-    if (!mIsDevSupportEnabled) {
-      return;
-    }
-
-    UiThreadUtil.runOnUiThread(
-        new Runnable() {
-          @Override
-          public void run() {
-            mDevSettings.setElementInspectorEnabled(!mDevSettings.isElementInspectorEnabled());
-            mReactInstanceManagerHelper.toggleElementInspector();
-          }
-        });
-  }
-
-  private void reload() {
-    UiThreadUtil.assertOnUiThread();
-
-    // reload settings, show/hide debug overlay if required & start/stop shake detector
-    if (mIsDevSupportEnabled) {
-      // update visibility of FPS debug overlay depending on the settings
-      if (mDebugOverlayController != null) {
-        mDebugOverlayController.setFpsDebugViewVisible(mDevSettings.isFpsDebugEnabled());
-      }
-
-      // start shake gesture detector
-      if (!mIsShakeDetectorStarted) {
-        mShakeDetector.start(
-            (SensorManager) mApplicationContext.getSystemService(Context.SENSOR_SERVICE));
-        mIsShakeDetectorStarted = true;
-      }
-
-      // register reload app broadcast receiver
-      if (!mIsReceiverRegistered) {
-        IntentFilter filter = new IntentFilter();
-        filter.addAction(getReloadAppAction(mApplicationContext));
-        mApplicationContext.registerReceiver(mReloadAppBroadcastReceiver, filter);
-        mIsReceiverRegistered = true;
-      }
-
-      // show the dev loading if it should be
-      if (mDevLoadingViewVisible) {
-        mDevLoadingViewController.showMessage("Reloading...");
-      }
-
-      mDevServerHelper.openPackagerConnection(this.getClass().getSimpleName(), this);
-      if (mDevSettings.isReloadOnJSChangeEnabled()) {
-        mDevServerHelper.startPollingOnChangeEndpoint(
-            new DevServerHelper.OnServerContentChangeListener() {
-              @Override
-              public void onServerContentChanged() {
                 handleReloadJS();
-              }
-            });
-      } else {
-        mDevServerHelper.stopPollingOnChangeEndpoint();
-      }
-    } else {
-      // hide FPS debug overlay
-      if (mDebugOverlayController != null) {
-        mDebugOverlayController.setFpsDebugViewVisible(false);
-      }
-
-      // stop shake gesture detector
-      if (mIsShakeDetectorStarted) {
-        mShakeDetector.stop();
-        mIsShakeDetectorStarted = false;
-      }
-
-      // unregister app reload broadcast receiver
-      if (mIsReceiverRegistered) {
-        mApplicationContext.unregisterReceiver(mReloadAppBroadcastReceiver);
-        mIsReceiverRegistered = false;
-      }
-
-      // hide redbox dialog
-      hideRedboxDialog();
-
-      // hide dev options dialog
-      hideDevOptionsDialog();
-
-      // hide loading view
-      mDevLoadingViewController.hide();
-      mDevServerHelper.closePackagerConnection();
-      mDevServerHelper.stopPollingOnChangeEndpoint();
+            }
+        });
     }
-  }
 
-  /** Intent action for reloading the JS */
-  private static String getReloadAppAction(Context context) {
-    return context.getPackageName() + RELOAD_APP_ACTION_SUFFIX;
-  }
+    @Override
+    public void onPackagerDevMenuCommand() {
+        UiThreadUtil.runOnUiThread(new Runnable() {
+
+            @Override
+            public void run() {
+                showDevOptionsDialog();
+            }
+        });
+    }
+
+    @Override
+    public void onCaptureHeapCommand(final Responder responder) {
+        UiThreadUtil.runOnUiThread(new Runnable() {
+
+            @Override
+            public void run() {
+                handleCaptureHeap(responder);
+            }
+        });
+    }
+
+    @Override
+    @Nullable
+    public Map<String, RequestHandler> customCommandHandlers() {
+        return mCustomPackagerCommandHandlers;
+    }
+
+    private void handleCaptureHeap(final Responder responder) {
+        if (mCurrentContext == null) {
+            return;
+        }
+        JSCHeapCapture heapCapture = mCurrentContext.getNativeModule(JSCHeapCapture.class);
+        heapCapture.captureHeap(mApplicationContext.getCacheDir().getPath(), new JSCHeapCapture.CaptureCallback() {
+
+            @Override
+            public void onSuccess(File capture) {
+                responder.respond(capture.toString());
+            }
+
+            @Override
+            public void onFailure(JSCHeapCapture.CaptureException error) {
+                responder.error(error.toString());
+            }
+        });
+    }
+
+    private void updateLastErrorInfo(@Nullable final String message, final StackFrame[] stack, final int errorCookie, final ErrorType errorType) {
+        mLastErrorTitle = message;
+        mLastErrorStack = stack;
+        mLastErrorCookie = errorCookie;
+        mLastErrorType = errorType;
+    }
+
+    private void reloadJSInProxyMode() {
+        // When using js proxy, there is no need to fetch JS bundle as proxy executor will do that
+        // anyway
+        mDevServerHelper.launchJSDevtools();
+        JavaJSExecutor.Factory factory = new JavaJSExecutor.Factory() {
+
+            @Override
+            public JavaJSExecutor create() throws Exception {
+                WebsocketJavaScriptExecutor executor = new WebsocketJavaScriptExecutor();
+                SimpleSettableFuture<Boolean> future = new SimpleSettableFuture<>();
+                executor.connect(mDevServerHelper.getWebsocketProxyURL(), getExecutorConnectCallback(future));
+                // TODO(t9349129) Don't use timeout
+                try {
+                    future.get(90, TimeUnit.SECONDS);
+                    return executor;
+                } catch (ExecutionException e) {
+                    throw (Exception) e.getCause();
+                } catch (InterruptedException | TimeoutException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        mReactInstanceManagerHelper.onReloadWithJSDebugger(factory);
+    }
+
+    private WebsocketJavaScriptExecutor.JSExecutorConnectCallback getExecutorConnectCallback(final SimpleSettableFuture<Boolean> future) {
+        return new WebsocketJavaScriptExecutor.JSExecutorConnectCallback() {
+
+            @Override
+            public void onSuccess() {
+                future.set(true);
+                mDevLoadingViewController.hide();
+                mDevLoadingViewVisible = false;
+            }
+
+            @Override
+            public void onFailure(final Throwable cause) {
+                mDevLoadingViewController.hide();
+                mDevLoadingViewVisible = false;
+                FLog.e(ReactConstants.TAG, "Failed to connect to debugger!", cause);
+                future.setException(new IOException(mApplicationContext.getString(R.string.reactandroid_catalyst_debug_error), cause));
+            }
+        };
+    }
+
+    public void reloadJSFromServer(final String bundleURL) {
+        ReactMarker.logMarker(ReactMarkerConstants.DOWNLOAD_START);
+        mDevLoadingViewController.showForUrl(bundleURL);
+        mDevLoadingViewVisible = true;
+        final BundleDownloader.BundleInfo bundleInfo = new BundleDownloader.BundleInfo();
+        mDevServerHelper.downloadBundleFromURL(new DevBundleDownloadListener() {
+
+            @Override
+            public void onSuccess(@Nullable final NativeDeltaClient nativeDeltaClient) {
+                mDevLoadingViewController.hide();
+                mDevLoadingViewVisible = false;
+                synchronized (DevSupportManagerImpl.this) {
+                    mBundleStatus.isLastDownloadSucess = true;
+                    mBundleStatus.updateTimestamp = System.currentTimeMillis();
+                }
+                if (mBundleDownloadListener != null) {
+                    mBundleDownloadListener.onSuccess(nativeDeltaClient);
+                }
+                UiThreadUtil.runOnUiThread(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        ReactMarker.logMarker(ReactMarkerConstants.DOWNLOAD_END, bundleInfo.toJSONString());
+                        mReactInstanceManagerHelper.onJSBundleLoadedFromServer(nativeDeltaClient);
+                    }
+                });
+            }
+
+            @Override
+            public void onProgress(@Nullable final String status, @Nullable final Integer done, @Nullable final Integer total) {
+                mDevLoadingViewController.updateProgress(status, done, total);
+                if (mBundleDownloadListener != null) {
+                    mBundleDownloadListener.onProgress(status, done, total);
+                }
+            }
+
+            @Override
+            public void onFailure(final Exception cause) {
+                mDevLoadingViewController.hide();
+                mDevLoadingViewVisible = false;
+                synchronized (DevSupportManagerImpl.this) {
+                    mBundleStatus.isLastDownloadSucess = false;
+                }
+                if (mBundleDownloadListener != null) {
+                    mBundleDownloadListener.onFailure(cause);
+                }
+                FLog.e(ReactConstants.TAG, "Unable to download JS bundle", cause);
+                UiThreadUtil.runOnUiThread(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        if (cause instanceof DebugServerException) {
+                            DebugServerException debugServerException = (DebugServerException) cause;
+                            showNewJavaError(debugServerException.getMessage(), cause);
+                        } else {
+                            showNewJavaError(mApplicationContext.getString(R.string.reactandroid_catalyst_reload_error), cause);
+                        }
+                    }
+                });
+            }
+        }, mJSBundleTempFile, bundleURL, bundleInfo);
+    }
+
+    @Override
+    public void startInspector() {
+        if (mIsDevSupportEnabled) {
+            mDevServerHelper.openInspectorConnection();
+        }
+    }
+
+    @Override
+    public void stopInspector() {
+        mDevServerHelper.closeInspectorConnection();
+    }
+
+    @Override
+    public void setHotModuleReplacementEnabled(final boolean isHotModuleReplacementEnabled) {
+        if (!mIsDevSupportEnabled) {
+            return;
+        }
+        UiThreadUtil.runOnUiThread(new Runnable() {
+
+            @Override
+            public void run() {
+                mDevSettings.setHotModuleReplacementEnabled(isHotModuleReplacementEnabled);
+                handleReloadJS();
+            }
+        });
+    }
+
+    @Override
+    public void setRemoteJSDebugEnabled(final boolean isRemoteJSDebugEnabled) {
+        if (!mIsDevSupportEnabled) {
+            return;
+        }
+        UiThreadUtil.runOnUiThread(new Runnable() {
+
+            @Override
+            public void run() {
+                mDevSettings.setRemoteJSDebugEnabled(isRemoteJSDebugEnabled);
+                handleReloadJS();
+            }
+        });
+    }
+
+    @Override
+    public void setReloadOnJSChangeEnabled(final boolean isReloadOnJSChangeEnabled) {
+        if (!mIsDevSupportEnabled) {
+            return;
+        }
+        UiThreadUtil.runOnUiThread(new Runnable() {
+
+            @Override
+            public void run() {
+                mDevSettings.setReloadOnJSChangeEnabled(isReloadOnJSChangeEnabled);
+                handleReloadJS();
+            }
+        });
+    }
+
+    @Override
+    public void setFpsDebugEnabled(final boolean isFpsDebugEnabled) {
+        if (!mIsDevSupportEnabled) {
+            return;
+        }
+        UiThreadUtil.runOnUiThread(new Runnable() {
+
+            @Override
+            public void run() {
+                mDevSettings.setFpsDebugEnabled(isFpsDebugEnabled);
+            }
+        });
+    }
+
+    @Override
+    public void toggleElementInspector() {
+        if (!mIsDevSupportEnabled) {
+            return;
+        }
+        UiThreadUtil.runOnUiThread(new Runnable() {
+
+            @Override
+            public void run() {
+                mDevSettings.setElementInspectorEnabled(!mDevSettings.isElementInspectorEnabled());
+                mReactInstanceManagerHelper.toggleElementInspector();
+            }
+        });
+    }
+
+    // NOTE(brentvatne): this is confusingly called the first time the app loads!
+    private void reload() {
+        UiThreadUtil.assertOnUiThread();
+        // reload settings, show/hide debug overlay if required & start/stop shake detector
+        if (mIsDevSupportEnabled) {
+            // update visibility of FPS debug overlay depending on the settings
+            if (mDebugOverlayController != null) {
+                mDebugOverlayController.setFpsDebugViewVisible(mDevSettings.isFpsDebugEnabled());
+            }
+            // start shake gesture detector
+            if (!mIsShakeDetectorStarted) {
+                mShakeDetector.start((SensorManager) mApplicationContext.getSystemService(Context.SENSOR_SERVICE));
+                mIsShakeDetectorStarted = true;
+            }
+            // register reload app broadcast receiver
+            if (!mIsReceiverRegistered) {
+                IntentFilter filter = new IntentFilter();
+                filter.addAction(getReloadAppAction(mApplicationContext));
+                mApplicationContext.registerReceiver(mReloadAppBroadcastReceiver, filter);
+                mIsReceiverRegistered = true;
+            }
+            // show the dev loading if it should be
+            if (mDevLoadingViewVisible) {
+                mDevLoadingViewController.showMessage("Reloading...");
+            }
+            mDevServerHelper.openPackagerConnection(this.getClass().getSimpleName(), this);
+            if (mDevSettings.isReloadOnJSChangeEnabled()) {
+                mDevServerHelper.startPollingOnChangeEndpoint(new DevServerHelper.OnServerContentChangeListener() {
+
+                    @Override
+                    public void onServerContentChanged() {
+                        handleReloadJS();
+                    }
+                });
+            } else {
+                mDevServerHelper.stopPollingOnChangeEndpoint();
+            }
+        } else {
+            // hide FPS debug overlay
+            if (mDebugOverlayController != null) {
+                mDebugOverlayController.setFpsDebugViewVisible(false);
+            }
+            // stop shake gesture detector
+            if (mIsShakeDetectorStarted) {
+                mShakeDetector.stop();
+                mIsShakeDetectorStarted = false;
+            }
+            // unregister app reload broadcast receiver
+            if (mIsReceiverRegistered) {
+                mApplicationContext.unregisterReceiver(mReloadAppBroadcastReceiver);
+                mIsReceiverRegistered = false;
+            }
+            // hide redbox dialog
+            hideRedboxDialog();
+            // hide dev options dialog
+            hideDevOptionsDialog();
+            // hide loading view
+            mDevLoadingViewController.hide();
+            mDevServerHelper.closePackagerConnection();
+            mDevServerHelper.stopPollingOnChangeEndpoint();
+        }
+    }
+
+    /** Intent action for reloading the JS */
+    private static String getReloadAppAction(Context context) {
+        return context.getPackageName() + RELOAD_APP_ACTION_SUFFIX;
+    }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DisabledDevSupportManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DisabledDevSupportManager.java
@@ -119,6 +119,10 @@ public class DisabledDevSupportManager implements DevSupportManager {
   @Override
   public void handleReloadJS() {}
 
+
+  @Override
+  public void reloadExpoApp() {}
+
   @Override
   public void reloadJSFromServer(String bundleURL) {}
 

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/RedBoxDialog.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/RedBoxDialog.java
@@ -249,7 +249,7 @@ import org.json.JSONObject;
         new View.OnClickListener() {
           @Override
           public void onClick(View v) {
-            mDevSupportManager.handleReloadJS();
+            mDevSupportManager.reloadExpoApp();
           }
         });
     mDismissButton = (Button) findViewById(R.id.rn_redbox_dismiss_button);
@@ -303,7 +303,7 @@ import org.json.JSONObject;
       return true;
     }
     if (mDoubleTapReloadRecognizer.didDoubleTapR(keyCode, getCurrentFocus())) {
-      mDevSupportManager.handleReloadJS();
+      mDevSupportManager.reloadExpoApp();
     }
     return super.onKeyUp(keyCode, event);
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.java
@@ -60,6 +60,8 @@ public interface DevSupportManager extends NativeModuleCallExceptionHandler {
 
   void handleReloadJS();
 
+  void reloadExpoApp();
+
   void reloadJSFromServer(final String bundleURL);
 
   void isPackagerRunning(PackagerStatusCallback callback);


### PR DESCRIPTION
# Why 

Fixes https://github.com/expo/expo/issues/6262.

# How

- reformatted changes from https://github.com/expo/react-native/commit/sdk-36 so that [the compare between commits](https://github.com/expo/react-native/compare/sdk-36~1..sdk-36-bare~3) looks as small as possible
- reverted changes that will be done by `ReactAndroidCodeTransformer` when we import `react-native-lab` to `android` https://github.com/expo/react-native/pull/20/commits/6f62ba22249393b7b0dbb090df1b6770c091eb7c
- prepared `react-native-lab` for `bare-expo` and for `ReactAndroidCodeTransformer` by (https://github.com/expo/react-native/pull/20/commits/3ba4045211fd1923a237e519b28dace3d737cd50):
  - extracting `getExponentActivityId` so `ReactAndroidCodeTransformer` can replace the `-1` with access to `mDevSettings.mSettings.exponentActivityId` which is added and exposed only by the transformer
  - reloading JS if expo-reloading fails (this would happen in `bare-expo`, what we want to do then is to just reload JS)
- instead of commenting out stuff right in `react-native-lab`, I added labels to statements that should be removed so that `ReactAndroidCodeTransformer` deletes them when importing to `expo` repo. https://github.com/expo/react-native/pull/20/commits/4c65ae2dcdd1b7356e9d8e5621fe12f6b08c6612