### PR TITLE
Remove polyfill for Linking.openSettings on iOS

### DIFF
--- a/Libraries/Linking/Linking.js
+++ b/Libraries/Linking/Linking.js
@@ -74,9 +74,6 @@ class Linking extends NativeEventEmitter {
    * See https://facebook.github.io/react-native/docs/linking.html#opensettings
    */
   openSettings(): Promise<any> {
-    if (Platform.OS === 'ios') {
-      return NativeLinking.openURL('app-settings:');
-    }
     return NativeLinking.openSettings();
   }
 


### PR DESCRIPTION
Follow up from https://github.com/expo/expo/pull/7717