### PR TITLE
[ios] Fix `EXC_BAD_ACCESS` in start method of `RCTCxxBridge`

### DIFF
--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -334,9 +334,28 @@ struct RCTInstanceCallback : public InstanceCallback {
   // Prepare executor factory (shared_ptr for copy into block)
   std::shared_ptr<JSExecutorFactory> executorFactory;
   if (!self.executorClass) {
-    if ([self.delegate respondsToSelector:@selector(jsExecutorFactoryForBridge:)]) {
-      id<RCTCxxBridgeDelegate> cxxDelegate = (id<RCTCxxBridgeDelegate>)self.delegate;
-      executorFactory = std::make_shared<JSCExecutorFactory>(*reinterpret_cast<JSCExecutorFactory *>([cxxDelegate jsExecutorFactoryForBridge:self]));
+    SEL jsExecutorFactoryForBridgeSEL = @selector(jsExecutorFactoryForBridge:);
+    if ([self.delegate respondsToSelector:jsExecutorFactoryForBridgeSEL]) {
+      // Normally, `RCTCxxBridgeDelegate` protocol uses `std::unique_ptr` to return the js executor object.
+      // However, we needed to change the signature of `jsExecutorFactoryForBridge` to return `void *` instead. See https://github.com/expo/expo/pull/9862.
+      // This change works great in Expo Go because we have full control over modules initialization,
+      // but if someone is using our fork in the bare app, crashes may occur (`EXC_BAD_ACCESS`).
+      // To fix it, we need to get the return type of `jsExecutorFactoryForBridge` and handle two cases:
+      // - method returns `void *`
+      // - method returns `std::unique_ptr<JSExecutorFactory>`
+      Method m = class_getInstanceMethod([self.delegate class], jsExecutorFactoryForBridgeSEL);
+      char returnType[128];
+      method_getReturnType(m, returnType, sizeof(returnType));
+      
+      if(strcmp(returnType, @encode(void *)) == 0) {
+        // `jsExecutorFactoryForBridge` returns `void *`
+        id<RCTCxxBridgeDelegate> cxxDelegate = (id<RCTCxxBridgeDelegate>)self.delegate;
+        executorFactory = std::make_shared<JSCExecutorFactory>(*reinterpret_cast<JSCExecutorFactory *>([cxxDelegate jsExecutorFactoryForBridge:self]));
+      } else {
+        // `jsExecutorFactoryForBridge` returns `std::unique_ptr<JSExecutorFactory>`
+        id<RCTCxxBridgeTurboModuleDelegate> cxxDelegate = (id<RCTCxxBridgeTurboModuleDelegate>)self.delegate;
+        executorFactory = [cxxDelegate jsExecutorFactoryForBridge:self];
+      }
     }
     if (!executorFactory) {
       executorFactory = std::make_shared<JSCExecutorFactory>(nullptr);

--- a/React/CxxBridge/RCTCxxBridgeDelegate.h
+++ b/React/CxxBridge/RCTCxxBridgeDelegate.h
@@ -31,3 +31,12 @@ class JSExecutorFactory;
 - (void *)jsExecutorFactoryForBridge:(RCTBridge *)bridge;
 
 @end
+
+@protocol RCTCxxBridgeTurboModuleDelegate <RCTBridgeDelegate>
+
+/**
+ * The RCTCxxBridgeDelegate used outside of the Expo Go.
+ */
+- (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge;
+
+@end


### PR DESCRIPTION
# Why 

Fixes:
```
Crashed Thread:        0  Dispatch queue: com.apple.main-thread
Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       KERN_INVALID_ADDRESS at 0x0000000000000119
Exception Note:        EXC_CORPSE_NOTIFY
Termination Signal:    Segmentation fault: 11
Termination Reason:    Namespace SIGNAL, Code 0xb
Terminating Process:   exc handler [19427]
VM Regions Near 0x119:
--> 
    __TEXT                 0000000101c69000-0000000102fc1000 [ 19.3M] r-x/r-x SM=COW  /Users/USER/Library/Developer/CoreSimulator/Devices/BBE20DAE-6B68-4A70-B515-1A9A2543AB12/data/Containers/Bundle/Application/2CF4257D-1903-49DA-ABCD-50424F4910C3/BareExpoDetox.app/BareExpoDetox
Application Specific Information:
CoreSimulator 732.18.6 - Device: iPhone 8 (BBE20DAE-6B68-4A70-B515-1A9A2543AB12) - Runtime: iOS 14.4 (18D46) - DeviceType: iPhone 8
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libobjc.A.dylib               	0x00007fff2018fa85 objc_retain + 5
1   dev.expo.Payments             	0x0000000101f6d781 -[UIResponder(Reanimated) jsExecutorFactoryForBridge:] + 49 (UIResponder+Reanimated.mm:35)
2   dev.expo.Payments             	0x0000000101fc31a1 -[RCTCxxBridge start] + 1214
3   dev.expo.Payments             	0x0000000101fb2bc0 -[RCTBridge setUp] + 464 (RCTBridge.m:321)
4   dev.expo.Payments             	0x0000000101fb22ac -[RCTBridge initWithDelegate:bundleURL:moduleProvider:launchOptions:] + 223 (RCTBridge.m:178)
5   dev.expo.Payments             	0x0000000101fb2142 -[RCTBridge initWithDelegate:launchOptions:] + 55 (RCTBridge.m:154)
6   dev.expo.Payments             	0x0000000101c6ec52 AppDelegate.initializeReactNativeBridge(_:) + 146 (AppDelegate.swift:47)
7   dev.expo.Payments             	0x0000000101c6dbf8 AppDelegate.application(_:didFinishLaunchingWithOptions:) + 344
8   dev.expo.Payments             	0x0000000101c6eb93 @objc AppDelegate.application(_:didFinishLaunchingWithOptions:) + 131
9   com.apple.UIKitCore           	0x00007fff24692fdd -[UIApplication _handleDelegateCallbacksWithOptions:isSuspended:restoreState:] + 232
10  com.apple.UIKitCore           	0x00007fff24694b5f -[UIApplication _callInitializationDelegatesWithActions:forCanvas:payload:fromOriginatingProcess:] + 3919
11  com.apple.UIKitCore           	0x00007fff2469a56d -[UIApplication _runWithMainScene:transitionContext:completion:] + 1237
12  com.apple.UIKitCore           	0x00007fff23cc36f7 -[_UISceneLifecycleMultiplexer completeApplicationLaunchWithFBSScene:transitionContext:] + 122
13  com.apple.UIKitCore           	0x00007fff24251d1e _UIScenePerformActionsWithLifecycleActionMask + 88
14  com.apple.UIKitCore           	0x00007fff23cc4206 __101-[_UISceneLifecycleMultiplexer _evalTransitionToSettings:fromSettings:forceExit:withTransitionStore:]_block_invoke + 198
15  com.apple.UIKitCore           	0x00007fff23cc3c18 -[_UISceneLifecycleMultiplexer _performBlock:withApplicationOfDeactivationReasons:fromReasons:] + 296
16  com.apple.UIKitCore           	0x00007fff23cc4037 -[_UISceneLifecycleMultiplexer _evalTransitionToSettings:fromSettings:forceExit:withTransitionStore:] + 819
17  com.apple.UIKitCore           	0x00007fff23cc38cb -[_UISceneLifecycleMultiplexer uiScene:transitionedFromState:withTransitionContext:] + 345
18  com.apple.UIKitCore           	0x00007fff23ccbb63 __186-[_UIWindowSceneFBSSceneTransitionContextDrivenLifecycleSettingsDiffAction _performActionsForUIScene:withUpdatedFBSScene:settingsDiff:fromSettings:transitionContext:lifecycleActionType:]_block_invoke + 178
19  com.apple.UIKitCore           	0x00007fff2415b613 +[BSAnimationSettings(UIKit) tryAnimatingWithSettings:actions:completion:] + 871
20  com.apple.UIKitCore           	0x00007fff2426e5c6 _UISceneSettingsDiffActionPerformChangesWithTransitionContext + 240
21  com.apple.UIKitCore           	0x00007fff23ccb869 -[_UIWindowSceneFBSSceneTransitionContextDrivenLifecycleSettingsDiffAction _performActionsForUIScene:withUpdatedFBSScene:settingsDiff:fromSettings:transitionContext:lifecycleActionType:] + 361
22  com.apple.UIKitCore           	0x00007fff23aee75f __64-[UIScene scene:didUpdateWithDiff:transitionContext:completion:]_block_invoke + 797
23  com.apple.UIKitCore           	0x00007fff23aed209 -[UIScene _emitSceneSettingsUpdateResponseForCompletion:afterSceneUpdateWork:] + 253
24  com.apple.UIKitCore           	0x00007fff23aee398 -[UIScene scene:didUpdateWithDiff:transitionContext:completion:] + 208
25  com.apple.UIKitCore           	0x00007fff24698a0c -[UIApplication workspace:didCreateScene:withTransitionContext:completion:] + 508
26  com.apple.UIKitCore           	0x00007fff24183a1f -[UIApplicationSceneClientAgent scene:didInitializeWithEvent:completion:] + 358
27  com.apple.FrontBoardServices  	0x00007fff25aa70ae -[FBSScene _callOutQueue_agent_didCreateWithTransitionContext:completion:] + 391
28  com.apple.FrontBoardServices  	0x00007fff25acfb41 __94-[FBSWorkspaceScenesClient createWithSceneID:groupID:parameters:transitionContext:completion:]_block_invoke.176 + 102
29  com.apple.FrontBoardServices  	0x00007fff25ab4ad5 -[FBSWorkspace _calloutQueue_executeCalloutFromSource:withBlock:] + 209
30  com.apple.FrontBoardServices  	0x00007fff25acf80f __94-[FBSWorkspaceScenesClient createWithSceneID:groupID:parameters:transitionContext:completion:]_block_invoke + 352
31  libdispatch.dylib             	0x00007fff20106508 _dispatch_client_callout + 8
32  libdispatch.dylib             	0x00007fff20109052 _dispatch_block_invoke_direct + 281
33  com.apple.FrontBoardServices  	0x00007fff25af57a5 __FBSSERIALQUEUE_IS_CALLING_OUT_TO_A_BLOCK__ + 30
34  com.apple.FrontBoardServices  	0x00007fff25af548b -[FBSSerialQueue _targetQueue_performNextIfPossible] + 433
35  com.apple.FrontBoardServices  	0x00007fff25af5950 -[FBSSerialQueue _performNextFromRunLoopSource] + 22
36  com.apple.CoreFoundation      	0x00007fff2039038a __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 17
37  com.apple.CoreFoundation      	0x00007fff20390282 __CFRunLoopDoSource0 + 180
38  com.apple.CoreFoundation      	0x00007fff2038f764 __CFRunLoopDoSources0 + 248
39  com.apple.CoreFoundation      	0x00007fff20389f2f __CFRunLoopRun + 878
40  com.apple.CoreFoundation      	0x00007fff203896d6 CFRunLoopRunSpecific + 567
41  com.apple.GraphicsServices    	0x00007fff2c257db3 GSEventRunModal + 139
42  com.apple.UIKitCore           	0x00007fff24696cf7 -[UIApplication _run] + 912
43  com.apple.UIKitCore           	0x00007fff2469bba8 UIApplicationMain + 101
44  dev.expo.Payments             	0x0000000101c6f748 main + 56 (AppDelegate.swift:20)
45  libdyld.dylib                 	0x00007fff2025a3e9 start + 1
```

# How

Normally, `RCTCxxBridgeDelegate` protocol uses `std::unique_ptr` to return the js executor object.
However, we needed to change the signature of `jsExecutorFactoryForBridge` to return `void *` instead. See https://github.com/expo/expo/pull/9862. This change works great in Expo Go because we have full control over modules initialization, but if someone is using our fork in the bare app, crashes may occur (`EXC_BAD_ACCESS`). To fix it, we need to get the return type of `jsExecutorFactoryForBridge` and handle two cases:
- method returns `void *`
- method returns `std::unique_ptr<JSExecutorFactory>`

# Test Plan

- Expo Go ✅
- Bare expo ✅
